### PR TITLE
fix: Rule engine target and capture match groups logic

### DIFF
--- a/internal/resource_edge_application_rule_engine.go
+++ b/internal/resource_edge_application_rule_engine.go
@@ -520,7 +520,14 @@ func (r *rulesEngineResource) Update(ctx context.Context, req resource.UpdateReq
 
 	var behaviors []edgeapplications.RulesEngineBehaviorEntry
 	for _, behavior := range plan.RulesEngine.Behaviors {
-		if behavior.TargetCaptureMatch.Target.IsNull() || behavior.TargetCaptureMatch.Target.IsUnknown() || behavior.TargetCaptureMatch.Target.ValueString() == "" {
+		if behavior.Name.ValueString() == "capture_match_groups" && behavior.TargetCaptureMatch.Target.ValueString() != "" {
+			resp.Diagnostics.AddError("capture_match_groups",
+				"Behavior capture_match_groups can not have a target value.")
+			return
+		}
+		switch {
+		case behavior.TargetCaptureMatch == nil:
+		case behavior.Name.ValueString() == "capture_match_groups":
 			RulesEngineBehaviorObject := edgeapplications.RulesEngineBehaviorObject{
 				Name: behavior.Name.ValueString(),
 				Target: edgeapplications.RulesEngineBehaviorObjectTarget{
@@ -530,10 +537,16 @@ func (r *rulesEngineResource) Update(ctx context.Context, req resource.UpdateReq
 				},
 			}
 			behaviors = append(behaviors, edgeapplications.RulesEngineBehaviorEntry{RulesEngineBehaviorObject: &RulesEngineBehaviorObject})
-		} else {
+		case behavior.TargetCaptureMatch.Target.ValueString() != "":
 			RulesEngineBehaviorString := edgeapplications.RulesEngineBehaviorString{
 				Name:   behavior.Name.ValueString(),
 				Target: behavior.TargetCaptureMatch.Target.ValueString(),
+			}
+			behaviors = append(behaviors, edgeapplications.RulesEngineBehaviorEntry{RulesEngineBehaviorString: &RulesEngineBehaviorString})
+		case behavior.TargetCaptureMatch.CapturedArray.IsUnknown() && behavior.TargetCaptureMatch.Regex.IsUnknown() && behavior.TargetCaptureMatch.Subject.IsUnknown():
+			RulesEngineBehaviorString := edgeapplications.RulesEngineBehaviorString{
+				Name:   behavior.Name.ValueString(),
+				Target: "",
 			}
 			behaviors = append(behaviors, edgeapplications.RulesEngineBehaviorEntry{RulesEngineBehaviorString: &RulesEngineBehaviorString})
 		}


### PR DESCRIPTION
We get the following error message when we try to update a rule with an action that does not have a value (e.g. `bypass_cache_phase`), but works fine on creation

`Error: 500 Internal Server Error`

This PR only copies the rule engine behavior from the [creation function](https://github.com/aziontech/terraform-provider-azion/blob/784463192c3dba4c1bebd3751edadafc54d18225/internal/resource_edge_application_rule_engine.go#L231-L262) to the update function