### PR TITLE
fix: Resources should be recreated when removed outside of Terraform

### DIFF
--- a/internal/resource_digitalcertificate.go
+++ b/internal/resource_digitalcertificate.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"io"
+	"net/http"
 	"strconv"
 	"time"
 )
@@ -233,6 +234,10 @@ func (r *digitalCertificateResource) Read(ctx context.Context, req resource.Read
 
 	certificateResponse, response, err := r.client.digitalCertificatesApi.RetrieveDigitalCertificateByIDApi.GetCertificate(ctx, CertificateID).Execute()
 	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		bodyBytes, erro := io.ReadAll(response.Body)
 		if erro != nil {
 			resp.Diagnostics.AddError(

--- a/internal/resource_dnssec.go
+++ b/internal/resource_dnssec.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -222,6 +223,10 @@ func (r *dnssecResource) Read(ctx context.Context, req resource.ReadRequest, res
 	}
 	getDnsSec, response, err := r.client.idnsApi.DNSSECAPI.GetZoneDnsSec(ctx, int32(zoneId)).Execute()
 	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		bodyBytes, erro := io.ReadAll(response.Body)
 		if erro != nil {
 			resp.Diagnostics.AddError(

--- a/internal/resource_domain.go
+++ b/internal/resource_domain.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -210,6 +211,10 @@ func (r *domainResource) Read(ctx context.Context, req resource.ReadRequest, res
 
 	getDomain, response, err := r.client.domainsApi.DomainsApi.GetDomain(ctx, domainId).Execute()
 	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		bodyBytes, erro := io.ReadAll(response.Body)
 		if erro != nil {
 			resp.Diagnostics.AddError(

--- a/internal/resource_edgeFunction.go
+++ b/internal/resource_edgeFunction.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -251,6 +252,10 @@ func (r *edgeFunctionResource) Read(ctx context.Context, req resource.ReadReques
 
 	getEdgeFunction, response, err := r.client.edgefunctionsApi.EdgeFunctionsAPI.EdgeFunctionsIdGet(ctx, edgeFunctionId).Execute()
 	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		bodyBytes, erro := io.ReadAll(response.Body)
 		if erro != nil {
 			resp.Diagnostics.AddError(

--- a/internal/resource_edge_application_cache_setting.go
+++ b/internal/resource_edge_application_cache_setting.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -416,6 +417,10 @@ func (r *edgeApplicationCacheSettingsResource) Read(ctx context.Context, req res
 
 	cacheSettingResponse, response, err := r.client.edgeApplicationsApi.EdgeApplicationsCacheSettingsAPI.EdgeApplicationsEdgeApplicationIdCacheSettingsCacheSettingsIdGet(ctx, EdgeApplicationId, CacheSettingId).Execute()
 	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		bodyBytes, erro := io.ReadAll(response.Body)
 		if erro != nil {
 			resp.Diagnostics.AddError(

--- a/internal/resource_edge_application_edge_functions_instance.go
+++ b/internal/resource_edge_application_edge_functions_instance.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -222,6 +223,10 @@ func (r *edgeFunctionsInstanceResource) Read(ctx context.Context, req resource.R
 
 	edgeFunctionInstancesResponse, response, err := r.client.edgeApplicationsApi.EdgeApplicationsEdgeFunctionsInstancesAPI.EdgeApplicationsEdgeApplicationIdFunctionsInstancesFunctionsInstancesIdGet(ctx, ApplicationID, functionsInstancesId).Execute()
 	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		bodyBytes, erro := io.ReadAll(response.Body)
 		if erro != nil {
 			resp.Diagnostics.AddError(

--- a/internal/resource_edge_application_main_setting.go
+++ b/internal/resource_edge_application_main_setting.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -323,6 +324,10 @@ func (r *edgeApplicationResource) Read(ctx context.Context, req resource.ReadReq
 
 	stateEdgeApplication, response, err := r.client.edgeApplicationsApi.EdgeApplicationsMainSettingsAPI.EdgeApplicationsIdGet(ctx, state.ID.ValueString()).Execute()
 	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		bodyBytes, erro := io.ReadAll(response.Body)
 		if erro != nil {
 			resp.Diagnostics.AddError(

--- a/internal/resource_edge_application_origin.go
+++ b/internal/resource_edge_application_origin.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -352,6 +353,10 @@ func (r *originResource) Read(ctx context.Context, req resource.ReadRequest, res
 
 	originResponse, response, err := r.client.edgeApplicationsApi.EdgeApplicationsOriginsAPI.EdgeApplicationsEdgeApplicationIdOriginsOriginKeyGet(ctx, ApplicationID, OriginKey).Execute()
 	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		bodyBytes, erro := io.ReadAll(response.Body)
 		if erro != nil {
 			resp.Diagnostics.AddError(

--- a/internal/resource_edge_application_rule_engine.go
+++ b/internal/resource_edge_application_rule_engine.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -405,6 +406,10 @@ func (r *rulesEngineResource) Read(ctx context.Context, req resource.ReadRequest
 
 	ruleEngineResponse, response, err := r.client.edgeApplicationsApi.EdgeApplicationsRulesEngineAPI.EdgeApplicationsEdgeApplicationIdRulesEnginePhaseRulesRuleIdGet(ctx, edgeApplicationID, phase, ruleID).Execute()
 	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		bodyBytes, erro := io.ReadAll(response.Body)
 		if erro != nil {
 			resp.Diagnostics.AddError(

--- a/internal/resource_edge_firewall_edge_functions_instance.go
+++ b/internal/resource_edge_firewall_edge_functions_instance.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -234,6 +235,10 @@ func (r *edgeFirewallFunctionsInstanceResource) Read(ctx context.Context, req re
 		EdgeFirewallEdgeFirewallIdFunctionsInstancesEdgeFunctionInstanceIdGet(ctx, edgeFirewallID, functionsInstancesId).
 		Execute()
 	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		bodyBytes, erro := io.ReadAll(response.Body)
 		if erro != nil {
 			resp.Diagnostics.AddError(

--- a/internal/resource_edge_firewall_main_setting.go
+++ b/internal/resource_edge_firewall_main_setting.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/aziontech/azionapi-go-sdk/edgefirewall"
 	"io"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -217,6 +218,10 @@ func (r *edgeFirewallResource) Read(ctx context.Context, req resource.ReadReques
 
 	edgeFirewallResponse, response, err := r.client.edgeFirewallApi.DefaultAPI.EdgeFirewallUuidGet(ctx, edgeFirewallID).Execute()
 	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		bodyBytes, erro := io.ReadAll(response.Body)
 		if erro != nil {
 			resp.Diagnostics.AddError(

--- a/internal/resource_environment_variable.go
+++ b/internal/resource_environment_variable.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/aziontech/azionapi-go-sdk/variables"
 	"io"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -194,6 +195,10 @@ func (r *environmentVariableResource) Read(ctx context.Context, req resource.Rea
 
 	getEnvironmentVariable, response, err := r.client.variablesApi.VariablesAPI.ApiVariablesRetrieve(ctx, uuid).Execute()
 	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		bodyBytes, erro := io.ReadAll(response.Body)
 		if erro != nil {
 			resp.Diagnostics.AddError(

--- a/internal/resource_network_list.go
+++ b/internal/resource_network_list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/aziontech/azionapi-go-sdk/networklist"
 	"io"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -196,6 +197,10 @@ func (r *networkListResource) Read(ctx context.Context, req resource.ReadRequest
 
 	getNetworkList, response, err := r.client.networkListApi.DefaultApi.NetworkListsUuidGet(ctx, networkListId).Execute()
 	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		bodyBytes, erro := io.ReadAll(response.Body)
 		if erro != nil {
 			resp.Diagnostics.AddError(

--- a/internal/resource_waf_rule_set.go
+++ b/internal/resource_waf_rule_set.go
@@ -5,6 +5,7 @@ import (
 	waf "github.com/aziontech/azionapi-go-sdk/waf"
 	"github.com/aziontech/terraform-provider-azion/internal/utils"
 	"io"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -294,6 +295,10 @@ func (r *wafRuleSetResource) Read(ctx context.Context, req resource.ReadRequest,
 
 	wafResponse, response, err := r.client.wafApi.WAFAPI.GetWAFRuleset(ctx, wafRuleSetID).Execute()
 	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		bodyBytes, erro := io.ReadAll(response.Body)
 		if erro != nil {
 			resp.Diagnostics.AddError(

--- a/internal/resource_zones.go
+++ b/internal/resource_zones.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -207,6 +208,10 @@ func (r *zoneResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	}
 	order, response, err := r.client.idnsApi.ZonesAPI.GetZone(ctx, int32(idPlan)).Execute()
 	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		bodyBytes, erro := io.ReadAll(response.Body)
 		if erro != nil {
 			resp.Diagnostics.AddError(


### PR DESCRIPTION
When a resource is created via Terraform and removed manually we should recreate the resource instead of returning the following error:
```
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: 404 Not Found
│ 
│   with azion_edge_application_rule_engine.example,
│   on resource.tf line 62, in resource "azion_edge_application_rule_engine" "example":
│   62: resource "azion_edge_application_rule_engine" "example" {
│ 
│ {"detail":"Not found."}
╵
```