### PR TITLE
fix: Resources should be recreated when removed outside of Terraform

### DIFF
--- a/internal/resource_digitalcertificate.go
+++ b/internal/resource_digitalcertificate.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -234,8 +235,13 @@ func (r *digitalCertificateResource) Read(ctx context.Context, req resource.Read
 		}
 	}
 
-	certificateResponse, response, err := r.client.digitalCertificatesApi.RetrieveDigitalCertificateByIDApi.GetCertificate(ctx, CertificateID).Execute() //nolint
+	certificateResponse, response, err := r.client.digitalCertificatesApi.
+		RetrieveDigitalCertificateByIDApi.GetCertificate(ctx, CertificateID).Execute() //nolint
 	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		bodyBytes, errReadAll := io.ReadAll(response.Body)
 		if errReadAll != nil {
 			resp.Diagnostics.AddError(

--- a/internal/resource_domain.go
+++ b/internal/resource_domain.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -212,8 +213,13 @@ func (r *domainResource) Read(ctx context.Context, req resource.ReadRequest, res
 		domainId = state.ID.ValueString()
 	}
 
-	getDomain, response, err := r.client.domainsApi.DomainsAPI.GetDomain(ctx, domainId).Execute() //nolint
+	getDomain, response, err := r.client.domainsApi.DomainsAPI.
+		GetDomain(ctx, domainId).Execute() //nolint
 	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		bodyBytes, errReadAll := io.ReadAll(response.Body)
 		if errReadAll != nil {
 			resp.Diagnostics.AddError(

--- a/internal/resource_edgeFunction.go
+++ b/internal/resource_edgeFunction.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -249,8 +250,13 @@ func (r *edgeFunctionResource) Read(ctx context.Context, req resource.ReadReques
 		}
 	}
 
-	getEdgeFunction, response, err := r.client.edgefunctionsApi.EdgeFunctionsAPI.EdgeFunctionsIdGet(ctx, edgeFunctionId).Execute() //nolint
+	getEdgeFunction, response, err := r.client.edgefunctionsApi.EdgeFunctionsAPI.
+		EdgeFunctionsIdGet(ctx, edgeFunctionId).Execute() //nolint
 	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		bodyBytes, errReadAll := io.ReadAll(response.Body)
 		if errReadAll != nil {
 			resp.Diagnostics.AddError(

--- a/internal/resource_edge_application_cache_setting.go
+++ b/internal/resource_edge_application_cache_setting.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -420,8 +421,15 @@ func (r *edgeApplicationCacheSettingsResource) Read(ctx context.Context, req res
 		return
 	}
 
-	cacheSettingResponse, response, err := r.client.edgeApplicationsApi.EdgeApplicationsCacheSettingsAPI.EdgeApplicationsEdgeApplicationIdCacheSettingsCacheSettingsIdGet(ctx, EdgeApplicationId, CacheSettingId).Execute() //nolint
+	cacheSettingResponse, response, err := r.client.edgeApplicationsApi.
+		EdgeApplicationsCacheSettingsAPI.
+		EdgeApplicationsEdgeApplicationIdCacheSettingsCacheSettingsIdGet(
+			ctx, EdgeApplicationId, CacheSettingId).Execute() //nolint
 	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		bodyBytes, errReadAll := io.ReadAll(response.Body)
 		if errReadAll != nil {
 			resp.Diagnostics.AddError(

--- a/internal/resource_edge_application_edge_functions_instance.go
+++ b/internal/resource_edge_application_edge_functions_instance.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -220,8 +221,15 @@ func (r *edgeFunctionsInstanceResource) Read(ctx context.Context, req resource.R
 		return
 	}
 
-	edgeFunctionInstancesResponse, response, err := r.client.edgeApplicationsApi.EdgeApplicationsEdgeFunctionsInstancesAPI.EdgeApplicationsEdgeApplicationIdFunctionsInstancesFunctionsInstancesIdGet(ctx, ApplicationID, functionsInstancesId).Execute() //nolint
+	edgeFunctionInstancesResponse, response, err := r.client.edgeApplicationsApi.
+		EdgeApplicationsEdgeFunctionsInstancesAPI.
+		EdgeApplicationsEdgeApplicationIdFunctionsInstancesFunctionsInstancesIdGet(
+			ctx, ApplicationID, functionsInstancesId).Execute() //nolint
 	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		bodyBytes, errReadAll := io.ReadAll(response.Body)
 		if errReadAll != nil {
 			resp.Diagnostics.AddError(

--- a/internal/resource_edge_application_main_setting.go
+++ b/internal/resource_edge_application_main_setting.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"sync"
 	"time"
@@ -367,6 +368,10 @@ func (r *edgeApplicationResource) Read(ctx context.Context, req resource.ReadReq
 		EdgeApplicationsMainSettingsAPI.
 		EdgeApplicationsIdGet(ctx, state.ID.ValueString()).Execute() //nolint
 	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		bodyBytes, errReadAll := io.ReadAll(response.Body)
 		if errReadAll != nil {
 			resp.Diagnostics.AddError(

--- a/internal/resource_edge_application_origin.go
+++ b/internal/resource_edge_application_origin.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -367,8 +368,14 @@ func (r *originResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	originResponse, response, err := r.client.edgeApplicationsApi.EdgeApplicationsOriginsAPI.EdgeApplicationsEdgeApplicationIdOriginsOriginKeyGet(ctx, ApplicationID, OriginKey).Execute() //nolint
+	originResponse, response, err := r.client.edgeApplicationsApi.
+		EdgeApplicationsOriginsAPI.EdgeApplicationsEdgeApplicationIdOriginsOriginKeyGet(
+		ctx, ApplicationID, OriginKey).Execute() //nolint
 	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		bodyBytes, errReadAll := io.ReadAll(response.Body)
 		if errReadAll != nil {
 			resp.Diagnostics.AddError(

--- a/internal/resource_edge_application_rule_engine.go
+++ b/internal/resource_edge_application_rule_engine.go
@@ -471,8 +471,15 @@ func (r *rulesEngineResource) Read(ctx context.Context, req resource.ReadRequest
 		phase = "request"
 	}
 
-	ruleEngineResponse, response, err := r.client.edgeApplicationsApi.EdgeApplicationsRulesEngineAPI.EdgeApplicationsEdgeApplicationIdRulesEnginePhaseRulesRuleIdGet(ctx, edgeApplicationID, phase, ruleID).Execute() //nolint
+	ruleEngineResponse, response, err := r.client.edgeApplicationsApi.
+		EdgeApplicationsRulesEngineAPI.
+		EdgeApplicationsEdgeApplicationIdRulesEnginePhaseRulesRuleIdGet(
+			ctx, edgeApplicationID, phase, ruleID).Execute() //nolint
 	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		bodyBytes, errReadAll := io.ReadAll(response.Body)
 		if errReadAll != nil {
 			resp.Diagnostics.AddError(

--- a/internal/resource_edge_firewall_edge_functions_instance.go
+++ b/internal/resource_edge_firewall_edge_functions_instance.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -230,10 +231,15 @@ func (r *edgeFirewallFunctionsInstanceResource) Read(ctx context.Context, req re
 		return
 	}
 
-	edgeFunctionInstancesResponse, response, err := r.client.edgefunctionsinstanceEdgefirewallApi.DefaultAPI.
-		EdgeFirewallEdgeFirewallIdFunctionsInstancesEdgeFunctionInstanceIdGet(ctx, edgeFirewallID, functionsInstancesId).
-		Execute() //nolint
+	edgeFunctionInstancesResponse, response, err := r.client.
+		edgefunctionsinstanceEdgefirewallApi.DefaultAPI.
+		EdgeFirewallEdgeFirewallIdFunctionsInstancesEdgeFunctionInstanceIdGet(
+			ctx, edgeFirewallID, functionsInstancesId).Execute() //nolint
 	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		bodyBytes, errReadAll := io.ReadAll(response.Body)
 		if errReadAll != nil {
 			resp.Diagnostics.AddError(

--- a/internal/resource_edge_firewall_main_setting.go
+++ b/internal/resource_edge_firewall_main_setting.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -217,8 +218,13 @@ func (r *edgeFirewallResource) Read(ctx context.Context, req resource.ReadReques
 		edgeFirewallID = state.ID.ValueString()
 	}
 
-	edgeFirewallResponse, response, err := r.client.edgeFirewallApi.DefaultAPI.EdgeFirewallUuidGet(ctx, edgeFirewallID).Execute() //nolint
+	edgeFirewallResponse, response, err := r.client.edgeFirewallApi.DefaultAPI.
+		EdgeFirewallUuidGet(ctx, edgeFirewallID).Execute() //nolint
 	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		bodyBytes, errReadAll := io.ReadAll(response.Body)
 		if errReadAll != nil {
 			resp.Diagnostics.AddError(

--- a/internal/resource_waf_rule_set.go
+++ b/internal/resource_waf_rule_set.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -295,6 +296,10 @@ func (r *wafRuleSetResource) Read(ctx context.Context, req resource.ReadRequest,
 
 	wafResponse, response, err := r.client.wafApi.WAFAPI.GetWAFRuleset(ctx, wafRuleSetID).Execute() //nolint
 	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		bodyBytes, errReadAll := io.ReadAll(response.Body)
 		if errReadAll != nil {
 			resp.Diagnostics.AddError(

--- a/internal/resource_zones.go
+++ b/internal/resource_zones.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"io"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -210,6 +211,10 @@ func (r *zoneResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	order, response, err := r.client.idnsApi.ZonesAPI.GetZone(ctx, int32(idPlan)).Execute() //nolint
 	if err != nil {
+		if response.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		bodyBytes, errReadAll := io.ReadAll(response.Body)
 		if errReadAll != nil {
 			resp.Diagnostics.AddError(


### PR DESCRIPTION
When a resource is created via Terraform and removed manually we should recreate the resource instead of returning the following error:


```
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: 404 Not Found
│ 
│   with azion_edge_application_rule_engine.example,
│   on resource.tf line 62, in resource "azion_edge_application_rule_engine" "example":
│   62: resource "azion_edge_application_rule_engine" "example" {
│ 
│ {"detail":"Not found."}
╵