### PR TITLE
refactor: harden API error handling and ImportState for WAF, network list, and DNS resources

### DIFF
--- a/internal/resource_api_error.go
+++ b/internal/resource_api_error.go
@@ -1,0 +1,19 @@
+package provider
+
+import (
+	"io"
+	"net/http"
+)
+
+func readAPIErrorBody(response *http.Response) string {
+	if response == nil || response.Body == nil {
+		return ""
+	}
+
+	bodyBytes, err := io.ReadAll(response.Body)
+	if err != nil {
+		return err.Error()
+	}
+
+	return string(bodyBytes)
+}

--- a/internal/resource_application_cache_setting.go
+++ b/internal/resource_application_cache_setting.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -316,7 +315,7 @@ func (r *applicationCacheSettingsResource) Create(ctx context.Context, req resou
 		CacheSettingRequest(*cacheSettingRequest).
 		Execute()
 	if err != nil {
-		if response.StatusCode == 429 {
+		if response != nil && response.StatusCode == 429 {
 			createdCacheSetting, response, err = utils.RetryOn429(func() (*azionapi.CacheSettingResponse, *http.Response, error) {
 				return r.client.api.ApplicationsCacheSettingsAPI.
 					CreateCacheSetting(ctx, applicationID.ValueInt64()).
@@ -333,13 +332,8 @@ func (r *applicationCacheSettingsResource) Create(ctx context.Context, req resou
 				return
 			}
 		} else {
-			bodyBytes, errReadAll := io.ReadAll(response.Body)
-			if errReadAll != nil {
-				resp.Diagnostics.AddError(errReadAll.Error(), "err")
-			}
-			bodyString := string(bodyBytes)
+			bodyString := readAPIErrorBody(response)
 			resp.Diagnostics.AddError(err.Error(), bodyString)
-			response.Body.Close()
 			return
 		}
 	}
@@ -551,15 +545,8 @@ func (r *applicationCacheSettingsResource) Read(ctx context.Context, req resourc
 				return
 			}
 		} else {
-			if response != nil {
-				bodyBytes, errReadAll := io.ReadAll(response.Body)
-				if errReadAll != nil {
-					resp.Diagnostics.AddError(errReadAll.Error(), "err")
-				}
-				bodyString := string(bodyBytes)
-				resp.Diagnostics.AddError(err.Error(), bodyString)
-				response.Body.Close()
-			}
+			bodyString := readAPIErrorBody(response)
+			resp.Diagnostics.AddError(err.Error(), bodyString)
 			return
 		}
 	}
@@ -655,7 +642,7 @@ func (r *applicationCacheSettingsResource) Update(ctx context.Context, req resou
 		PatchedCacheSettingRequest(*patchedRequest).
 		Execute()
 	if err != nil {
-		if response.StatusCode == 429 {
+		if response != nil && response.StatusCode == 429 {
 			updatedCacheSetting, response, err = utils.RetryOn429(func() (*azionapi.CacheSettingResponse, *http.Response, error) {
 				return r.client.api.ApplicationsCacheSettingsAPI.
 					PartialUpdateCacheSetting(ctx, applicationID.ValueInt64(), cacheID.ValueInt64()).
@@ -672,13 +659,8 @@ func (r *applicationCacheSettingsResource) Update(ctx context.Context, req resou
 				return
 			}
 		} else {
-			bodyBytes, errReadAll := io.ReadAll(response.Body)
-			if errReadAll != nil {
-				resp.Diagnostics.AddError(errReadAll.Error(), "err")
-			}
-			bodyString := string(bodyBytes)
+			bodyString := readAPIErrorBody(response)
 			resp.Diagnostics.AddError(err.Error(), bodyString)
-			response.Body.Close()
 			return
 		}
 	}
@@ -877,11 +859,7 @@ func (r *applicationCacheSettingsResource) Delete(ctx context.Context, req resou
 		if response != nil && response.StatusCode == http.StatusNotFound {
 			return
 		}
-		bodyBytes, errReadAll := io.ReadAll(response.Body)
-		if errReadAll != nil {
-			resp.Diagnostics.AddError(errReadAll.Error(), "err")
-		}
-		bodyString := string(bodyBytes)
+		bodyString := readAPIErrorBody(response)
 		resp.Diagnostics.AddError(err.Error(), bodyString)
 		return
 	}
@@ -910,67 +888,12 @@ func (r *applicationCacheSettingsResource) ImportState(ctx context.Context, req 
 		return
 	}
 
-	// Set the application ID
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("application_id"), applicationId)...)
-
-	// Read the cache setting using the V4 API
-	cacheSettingResponse, response, err := r.client.api.ApplicationsCacheSettingsAPI.
-		RetrieveCacheSetting(ctx, applicationId, cacheSettingId).
-		Execute()
-	if err != nil {
-		if response != nil && response.StatusCode == http.StatusNotFound {
-			resp.Diagnostics.AddError("Cache setting not found", "")
-			return
-		}
-		if response != nil && response.StatusCode == 429 {
-			cacheSettingResponse, response, err = utils.RetryOn429(func() (*azionapi.CacheSettingResponse, *http.Response, error) {
-				return r.client.api.ApplicationsCacheSettingsAPI.
-					RetrieveCacheSetting(ctx, applicationId, cacheSettingId).
-					Execute()
-			}, 5)
-
-			if response != nil {
-				defer response.Body.Close()
-			}
-
-			if err != nil {
-				resp.Diagnostics.AddError(err.Error(), "API request failed after too many retries")
-				return
-			}
-		} else {
-			if response != nil {
-				bodyBytes, errReadAll := io.ReadAll(response.Body)
-				if errReadAll != nil {
-					resp.Diagnostics.AddError(errReadAll.Error(), "err")
-				}
-				bodyString := string(bodyBytes)
-				resp.Diagnostics.AddError(err.Error(), bodyString)
-				response.Body.Close()
-			}
-			return
-		}
-	}
-	if response != nil {
-		defer response.Body.Close()
-	}
-
-	// Ensure we got a valid response
-	if cacheSettingResponse == nil {
-		resp.Diagnostics.AddError("Empty response", "cacheSettingResponse is nil after successful API call")
-		return
-	}
-
-	cacheSettingData, ok := cacheSettingResponse.GetDataOk()
-	if !ok || cacheSettingData == nil {
-		resp.Diagnostics.AddError("Empty response", "cacheSettingResponse has no data after successful API call")
-		return
-	}
-
-	// Build state
 	state := ApplicationCacheSettingsResourceModel{
 		ApplicationID: types.Int64Value(applicationId),
-		CacheSetting:  transformCacheSettingResponseToResourceModel(cacheSettingData),
-		ID:            types.Int64Value(cacheSettingId),
+		CacheSetting: &CacheSettingResourceModel{
+			ID: types.Int64Value(cacheSettingId),
+		},
+		ID: types.Int64Value(cacheSettingId),
 	}
 
 	diags := resp.State.Set(ctx, &state)

--- a/internal/resource_application_functions_instance.go
+++ b/internal/resource_application_functions_instance.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -141,7 +140,7 @@ func (r *functionInstanceResource) Create(ctx context.Context, req resource.Crea
 
 	functionInstanceResponse, response, err := r.client.api.ApplicationsFunctionAPI.CreateApplicationFunctionInstance(ctx, plan.ApplicationID.ValueInt64()).FunctionInstanceRequest(functionInstanceRequest).Execute() //nolint
 	if err != nil {
-		if response.StatusCode == 429 {
+		if response != nil && response.StatusCode == 429 {
 			functionInstanceResponse, response, err = utils.RetryOn429(func() (*azionapi.FunctionInstanceResponse, *http.Response, error) {
 				return r.client.api.ApplicationsFunctionAPI.CreateApplicationFunctionInstance(ctx, plan.ApplicationID.ValueInt64()).FunctionInstanceRequest(functionInstanceRequest).Execute() //nolint
 			}, 5) // Maximum 5 retries
@@ -158,14 +157,7 @@ func (r *functionInstanceResource) Create(ctx context.Context, req resource.Crea
 				return
 			}
 		} else {
-			bodyBytes, errReadAll := io.ReadAll(response.Body)
-			if errReadAll != nil {
-				resp.Diagnostics.AddError(
-					errReadAll.Error(),
-					"err",
-				)
-			}
-			bodyString := string(bodyBytes)
+			bodyString := readAPIErrorBody(response)
 			resp.Diagnostics.AddError(
 				err.Error(),
 				bodyString,
@@ -211,29 +203,8 @@ func (r *functionInstanceResource) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 
-	var applicationID int64
-	var functionInstanceID int64
-
-	// ID can be either just the instance ID or "applicationID/instanceID" format for import
-	idStr := strconv.FormatInt(state.ID.ValueInt64(), 10)
-	valueFromCmd := strings.Split(idStr, "/")
-	if len(valueFromCmd) > 1 {
-		appID, err := strconv.ParseInt(valueFromCmd[0], 10, 64)
-		if err != nil {
-			resp.Diagnostics.AddError("Invalid application ID format", err.Error())
-			return
-		}
-		instanceID, err := strconv.ParseInt(valueFromCmd[1], 10, 64)
-		if err != nil {
-			resp.Diagnostics.AddError("Invalid instance ID format", err.Error())
-			return
-		}
-		applicationID = appID
-		functionInstanceID = instanceID
-	} else {
-		applicationID = state.ApplicationID.ValueInt64()
-		functionInstanceID = state.ID.ValueInt64()
-	}
+	applicationID := state.ApplicationID.ValueInt64()
+	functionInstanceID := state.ID.ValueInt64()
 
 	if functionInstanceID == 0 {
 		resp.Diagnostics.AddError(
@@ -246,11 +217,11 @@ func (r *functionInstanceResource) Read(ctx context.Context, req resource.ReadRe
 	functionInstanceResponse, response, err := r.client.api.ApplicationsFunctionAPI.
 		RetrieveApplicationFunctionInstance(ctx, applicationID, functionInstanceID).Execute() //nolint
 	if err != nil {
-		if response.StatusCode == http.StatusNotFound {
+		if response != nil && response.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		if response.StatusCode == 429 {
+		if response != nil && response.StatusCode == 429 {
 			functionInstanceResponse, response, err = utils.RetryOn429(func() (*azionapi.FunctionInstanceResponse, *http.Response, error) {
 				return r.client.api.ApplicationsFunctionAPI.
 					RetrieveApplicationFunctionInstance(ctx, applicationID, functionInstanceID).Execute() //nolint
@@ -268,14 +239,7 @@ func (r *functionInstanceResource) Read(ctx context.Context, req resource.ReadRe
 				return
 			}
 		} else {
-			bodyBytes, errReadAll := io.ReadAll(response.Body)
-			if errReadAll != nil {
-				resp.Diagnostics.AddError(
-					errReadAll.Error(),
-					"err",
-				)
-			}
-			bodyString := string(bodyBytes)
+			bodyString := readAPIErrorBody(response)
 			resp.Diagnostics.AddError(
 				err.Error(),
 				bodyString,
@@ -362,7 +326,7 @@ func (r *functionInstanceResource) Update(ctx context.Context, req resource.Upda
 
 	functionInstanceUpdateResponse, response, err := r.client.api.ApplicationsFunctionAPI.PartialUpdateApplicationFunctionInstance(ctx, plan.ApplicationID.ValueInt64(), functionInstanceID.ValueInt64()).PatchedFunctionInstanceRequest(patchRequest).Execute() //nolint
 	if err != nil {
-		if response.StatusCode == 429 {
+		if response != nil && response.StatusCode == 429 {
 			functionInstanceUpdateResponse, response, err = utils.RetryOn429(func() (*azionapi.FunctionInstanceResponse, *http.Response, error) {
 				return r.client.api.ApplicationsFunctionAPI.PartialUpdateApplicationFunctionInstance(ctx, plan.ApplicationID.ValueInt64(), functionInstanceID.ValueInt64()).PatchedFunctionInstanceRequest(patchRequest).Execute() //nolint
 			}, 5) // Maximum 5 retries
@@ -379,14 +343,7 @@ func (r *functionInstanceResource) Update(ctx context.Context, req resource.Upda
 				return
 			}
 		} else {
-			bodyBytes, errReadAll := io.ReadAll(response.Body)
-			if errReadAll != nil {
-				resp.Diagnostics.AddError(
-					errReadAll.Error(),
-					"error while reading response body",
-				)
-			}
-			bodyString := string(bodyBytes)
+			bodyString := readAPIErrorBody(response)
 			resp.Diagnostics.AddError(
 				err.Error(),
 				bodyString,
@@ -459,14 +416,7 @@ func (r *functionInstanceResource) Delete(ctx context.Context, req resource.Dele
 			// Resource already deleted, consider this a success
 			return
 		}
-		bodyBytes, errReadAll := io.ReadAll(response.Body)
-		if errReadAll != nil {
-			resp.Diagnostics.AddError(
-				errReadAll.Error(),
-				"err",
-			)
-		}
-		bodyString := string(bodyBytes)
+		bodyString := readAPIErrorBody(response)
 		resp.Diagnostics.AddError(
 			err.Error(),
 			bodyString,

--- a/internal/resource_application_main_setting.go
+++ b/internal/resource_application_main_setting.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"strconv"
 	"sync"
@@ -11,7 +10,6 @@ import (
 
 	sdk "github.com/aziontech/azionapi-v4-go-sdk-dev/azion-api"
 	"github.com/aziontech/terraform-provider-azion/internal/utils"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
@@ -194,14 +192,7 @@ func (r *applicationResource) Create(ctx context.Context, req resource.CreateReq
 				return
 			}
 		} else {
-			bodyBytes, errReadAll := io.ReadAll(response.Body)
-			if errReadAll != nil {
-				resp.Diagnostics.AddError(
-					errReadAll.Error(),
-					"err",
-				)
-			}
-			bodyString := string(bodyBytes)
+			bodyString := readAPIErrorBody(response)
 			resp.Diagnostics.AddError(
 				err.Error(),
 				bodyString,
@@ -296,14 +287,7 @@ func (r *applicationResource) Read(ctx context.Context, req resource.ReadRequest
 				return
 			}
 		} else {
-			bodyBytes, errReadAll := io.ReadAll(response.Body)
-			if errReadAll != nil {
-				resp.Diagnostics.AddError(
-					errReadAll.Error(),
-					"err",
-				)
-			}
-			bodyString := string(bodyBytes)
+			bodyString := readAPIErrorBody(response)
 			resp.Diagnostics.AddError(
 				err.Error(),
 				bodyString,
@@ -410,14 +394,7 @@ func (r *applicationResource) Update(ctx context.Context, req resource.UpdateReq
 				return
 			}
 		} else {
-			bodyBytes, errReadAll := io.ReadAll(response.Body)
-			if errReadAll != nil {
-				resp.Diagnostics.AddError(
-					errReadAll.Error(),
-					"err",
-				)
-			}
-			bodyString := string(bodyBytes)
+			bodyString := readAPIErrorBody(response)
 			resp.Diagnostics.AddError(
 				err.Error(),
 				bodyString,
@@ -466,14 +443,7 @@ func (r *applicationResource) Delete(ctx context.Context, req resource.DeleteReq
 		if response != nil && response.StatusCode == http.StatusNotFound {
 			return
 		}
-		bodyBytes, errReadAll := io.ReadAll(response.Body)
-		if errReadAll != nil {
-			resp.Diagnostics.AddError(
-				errReadAll.Error(),
-				"err",
-			)
-		}
-		bodyString := string(bodyBytes)
+		bodyString := readAPIErrorBody(response)
 		resp.Diagnostics.AddError(
 			err.Error(),
 			bodyString,
@@ -483,7 +453,21 @@ func (r *applicationResource) Delete(ctx context.Context, req resource.DeleteReq
 }
 
 func (r *applicationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	applicationID, err := strconv.ParseInt(req.ID, 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid application ID format", err.Error())
+		return
+	}
+
+	state := ApplicationResourceModel{
+		ID: types.StringValue(req.ID),
+		Application: &ApplicationResults{
+			ApplicationID: types.Int64Value(applicationID),
+		},
+	}
+
+	diags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
 }
 
 func transformModuleIntoRequest(modsPlan *ApplicationModules) sdk.ApplicationModulesRequest {

--- a/internal/resource_connector.go
+++ b/internal/resource_connector.go
@@ -2,10 +2,12 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	azionapi "github.com/aziontech/azionapi-v4-go-sdk-dev/azion-api"
@@ -547,18 +549,12 @@ func (r *connectorResource) Create(ctx context.Context, req resource.CreateReque
 	}
 
 	// Read the connector back to ensure we have the complete state with all API defaults.
-	getConnector, response, err := r.client.api.ConnectorsAPI.RetrieveConnector(ctx, connectorId).Execute() //nolint
-	if response != nil {
-		defer response.Body.Close()
-	}
+	connectorData, response, err := retrieveConnectorRaw(ctx, r.client, connectorId)
 	if err != nil {
 		if response != nil && response.StatusCode == http.StatusTooManyRequests {
-			getConnector, response, err = utils.RetryOn429(func() (*azionapi.ConnectorResponse, *http.Response, error) {
-				return r.client.api.ConnectorsAPI.RetrieveConnector(ctx, connectorId).Execute()
+			connectorData, response, err = utils.RetryOn429(func() (*connectorRawData, *http.Response, error) {
+				return retrieveConnectorRaw(ctx, r.client, connectorId)
 			}, 5)
-			if response != nil {
-				defer response.Body.Close()
-			}
 			if err != nil {
 				resp.Diagnostics.AddError(err.Error(), "API request failed after too many retries")
 				return
@@ -569,7 +565,7 @@ func (r *connectorResource) Create(ctx context.Context, req resource.CreateReque
 		}
 	}
 
-	r.populateConnectorFromResponse(ctx, plan.Connector, getConnector.GetData())
+	r.populateConnectorFromRaw(plan.Connector, connectorData)
 	plan.ID = types.StringValue(strconv.FormatInt(plan.Connector.ID.ValueInt64(), 10))
 	plan.LastUpdated = types.StringValue(time.Now().Format(time.RFC850))
 	plan.SchemaVersion = types.Int64Value(0)
@@ -598,6 +594,151 @@ func getConnectorId(connector azionapi.Connector) int64 {
 	}
 }
 
+type connectorRawResponse struct {
+	Data connectorRawData `json:"data"`
+}
+
+type connectorRawData struct {
+	ID             int64           `json:"id"`
+	Name           string          `json:"name"`
+	LastEditor     string          `json:"last_editor"`
+	LastModified   *time.Time      `json:"last_modified"`
+	CreatedAt      *time.Time      `json:"created_at"`
+	ProductVersion string          `json:"product_version"`
+	Active         *bool           `json:"active"`
+	Type           string          `json:"type"`
+	State          *string         `json:"version_state"`
+	VersionID      *string         `json:"version_id"`
+	Attributes     json.RawMessage `json:"attributes"`
+}
+
+type storageConnectorRawAttributes struct {
+	Bucket string  `json:"bucket"`
+	Prefix *string `json:"prefix"`
+}
+
+type httpConnectorRawAttributes struct {
+	Addresses         []httpConnectorRawAddress `json:"addresses"`
+	ConnectionOptions *httpConnectorRawOptions  `json:"connection_options"`
+	Modules           *httpConnectorRawModules  `json:"modules"`
+}
+
+type httpConnectorRawAddress struct {
+	Active    *bool                           `json:"active"`
+	Address   string                          `json:"address"`
+	HTTPPort  *int64                          `json:"http_port"`
+	HTTPSPort *int64                          `json:"https_port"`
+	Modules   *httpConnectorRawAddressModules `json:"modules"`
+}
+
+type httpConnectorRawAddressModules struct {
+	LoadBalancer *httpConnectorRawAddressLoadBalancer `json:"load_balancer"`
+}
+
+type httpConnectorRawAddressLoadBalancer struct {
+	ServerRole *string `json:"server_role"`
+	Weight     *int64  `json:"weight"`
+}
+
+type httpConnectorRawOptions struct {
+	DNSResolution     *string `json:"dns_resolution"`
+	FollowingRedirect *bool   `json:"following_redirect"`
+	Host              *string `json:"host"`
+	HTTPVersionPolicy *string `json:"http_version_policy"`
+	PathPrefix        *string `json:"path_prefix"`
+	RealIPHeader      *string `json:"real_ip_header"`
+	RealPortHeader    *string `json:"real_port_header"`
+	TransportPolicy   *string `json:"transport_policy"`
+}
+
+type httpConnectorRawModules struct {
+	LoadBalancer *httpConnectorRawLoadBalancer `json:"load_balancer"`
+	OriginShield *httpConnectorRawOriginShield `json:"origin_shield"`
+}
+
+type httpConnectorRawLoadBalancer struct {
+	Enabled *bool                               `json:"enabled"`
+	Config  *httpConnectorRawLoadBalancerConfig `json:"config"`
+}
+
+type httpConnectorRawLoadBalancerConfig struct {
+	Method            *string `json:"method"`
+	MaxRetries        *int64  `json:"max_retries"`
+	ConnectionTimeout *int64  `json:"connection_timeout"`
+	ReadWriteTimeout  *int64  `json:"read_write_timeout"`
+}
+
+type httpConnectorRawOriginShield struct {
+	Enabled *bool                         `json:"enabled"`
+	Config  *httpConnectorRawOriginConfig `json:"config"`
+}
+
+type httpConnectorRawOriginConfig struct {
+	OriginIPAcl *httpConnectorRawOriginIPAcl `json:"origin_ip_acl"`
+	Hmac        *httpConnectorRawHMAC        `json:"hmac"`
+}
+
+type httpConnectorRawOriginIPAcl struct {
+	Enabled *bool `json:"enabled"`
+}
+
+type httpConnectorRawHMAC struct {
+	Enabled *bool                       `json:"enabled"`
+	Config  *httpConnectorRawHMACConfig `json:"config"`
+}
+
+type httpConnectorRawHMACConfig struct {
+	Type       *string                    `json:"type"`
+	Attributes *httpConnectorRawHMACAttrs `json:"attributes"`
+}
+
+type httpConnectorRawHMACAttrs struct {
+	Region    *string `json:"region"`
+	Service   *string `json:"service"`
+	AccessKey *string `json:"access_key"`
+	SecretKey *string `json:"secret_key"`
+}
+
+func retrieveConnectorRaw(ctx context.Context, client *apiClient, connectorID int64) (*connectorRawData, *http.Response, error) {
+	baseURL := strings.TrimRight(client.apiConfig.Servers[0].URL, "/")
+	url := fmt.Sprintf("%s/workspace/connectors/%d", baseURL, connectorID)
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	for k, v := range client.apiConfig.DefaultHeader {
+		httpReq.Header.Set(k, v)
+	}
+	httpReq.Header.Set("User-Agent", client.apiConfig.UserAgent)
+
+	httpClient := client.apiConfig.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	httpResp, err := httpClient.Do(httpReq)
+	if err != nil {
+		return nil, httpResp, err
+	}
+	defer httpResp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, httpResp, err
+	}
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		return nil, httpResp, fmt.Errorf("API returned status %d: %s", httpResp.StatusCode, string(bodyBytes))
+	}
+
+	var raw connectorRawResponse
+	if err := json.Unmarshal(bodyBytes, &raw); err != nil {
+		return nil, httpResp, err
+	}
+
+	return &raw.Data, httpResp, nil
+}
+
 func (r *connectorResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state connectorResourceModel
 	diags := req.State.Get(ctx, &state)
@@ -621,22 +762,16 @@ func (r *connectorResource) Read(ctx context.Context, req resource.ReadRequest, 
 		}
 	}
 
-	getConnector, response, err := r.client.api.ConnectorsAPI.RetrieveConnector(ctx, connectorId).Execute() //nolint
-	if response != nil {
-		defer response.Body.Close()
-	}
+	connectorData, response, err := retrieveConnectorRaw(ctx, r.client, connectorId)
 	if err != nil {
 		if response != nil && response.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
 			return
 		}
 		if response != nil && response.StatusCode == http.StatusTooManyRequests {
-			getConnector, response, err = utils.RetryOn429(func() (*azionapi.ConnectorResponse, *http.Response, error) {
-				return r.client.api.ConnectorsAPI.RetrieveConnector(ctx, connectorId).Execute()
+			connectorData, response, err = utils.RetryOn429(func() (*connectorRawData, *http.Response, error) {
+				return retrieveConnectorRaw(ctx, r.client, connectorId)
 			}, 5)
-			if response != nil {
-				defer response.Body.Close()
-			}
 			if err != nil {
 				resp.Diagnostics.AddError(err.Error(), "API request failed after too many retries")
 				return
@@ -647,7 +782,10 @@ func (r *connectorResource) Read(ctx context.Context, req resource.ReadRequest, 
 		}
 	}
 
-	r.populateConnectorFromResponse(ctx, state.Connector, getConnector.GetData())
+	if state.Connector == nil {
+		state.Connector = &connectorResourceResults{}
+	}
+	r.populateConnectorFromRaw(state.Connector, connectorData)
 	state.ID = types.StringValue(strconv.FormatInt(state.Connector.ID.ValueInt64(), 10))
 	state.SchemaVersion = types.Int64Value(0)
 
@@ -673,7 +811,17 @@ func (r *connectorResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	connectorId := state.Connector.ID.ValueInt64()
+	var connectorId int64
+	if state.Connector != nil && !state.Connector.ID.IsNull() {
+		connectorId = state.Connector.ID.ValueInt64()
+	} else {
+		parsedID, err := strconv.ParseInt(state.ID.ValueString(), 10, 64)
+		if err != nil {
+			resp.Diagnostics.AddError("Value Conversion error ", "Could not convert Connector ID")
+			return
+		}
+		connectorId = parsedID
+	}
 	connectorType := plan.Connector.Type.ValueString()
 
 	// Build and send the appropriate update request based on connector type.
@@ -769,7 +917,17 @@ func (r *connectorResource) Delete(ctx context.Context, req resource.DeleteReque
 		return
 	}
 
-	connectorId := state.Connector.ID.ValueInt64()
+	var connectorId int64
+	if state.Connector != nil && !state.Connector.ID.IsNull() {
+		connectorId = state.Connector.ID.ValueInt64()
+	} else {
+		parsedID, err := strconv.ParseInt(state.ID.ValueString(), 10, 64)
+		if err != nil {
+			resp.Diagnostics.AddError("Value Conversion error ", "Could not convert Connector ID")
+			return
+		}
+		connectorId = parsedID
+	}
 
 	_, response, err := utils.RetryOn429Delete(func() (*azionapi.DeleteResponse, *http.Response, error) {
 		return r.client.api.ConnectorsAPI.DeleteConnector(ctx, connectorId).Execute()
@@ -796,36 +954,13 @@ func (r *connectorResource) ImportState(ctx context.Context, req resource.Import
 		return
 	}
 
-	// First, get the connector from API to determine its type
-	getConnector, response, err := r.client.api.ConnectorsAPI.RetrieveConnector(ctx, connectorId).Execute()
-	if response != nil {
-		defer response.Body.Close()
-	}
-	if err != nil {
-		if response != nil && response.StatusCode == http.StatusTooManyRequests {
-			getConnector, response, err = utils.RetryOn429(func() (*azionapi.ConnectorResponse, *http.Response, error) {
-				return r.client.api.ConnectorsAPI.RetrieveConnector(ctx, connectorId).Execute()
-			}, 5)
-			if response != nil {
-				defer response.Body.Close()
-			}
-			if err != nil {
-				resp.Diagnostics.AddError(err.Error(), "API request failed after too many retries")
-				return
-			}
-		} else {
-			addConnectorAPIError(&resp.Diagnostics, err, response, "import")
-			return
-		}
-	}
-
-	// Create the model and populate it from response
 	state := &connectorResourceModel{
-		Connector: &connectorResourceResults{},
+		ID:            types.StringValue(req.ID),
+		SchemaVersion: types.Int64Value(0),
+		Connector: &connectorResourceResults{
+			ID: types.Int64Value(connectorId),
+		},
 	}
-	r.populateConnectorFromResponse(ctx, state.Connector, getConnector.GetData())
-	state.ID = types.StringValue(strconv.FormatInt(connectorId, 10))
-	state.SchemaVersion = types.Int64Value(0)
 
 	diags := resp.State.Set(ctx, state)
 	resp.Diagnostics.Append(diags...)
@@ -1154,6 +1289,156 @@ func (r *connectorResource) populateConnectorFromResponse(ctx context.Context, m
 		// Clear storage attributes
 		model.StorageAttrs = nil
 	}
+}
+
+func (r *connectorResource) populateConnectorFromRaw(model *connectorResourceResults, connector *connectorRawData) {
+	if model == nil || connector == nil {
+		return
+	}
+
+	model.ID = types.Int64Value(connector.ID)
+	model.Name = types.StringValue(connector.Name)
+	model.LastEditor = types.StringValue(connector.LastEditor)
+	if connector.LastModified != nil {
+		model.LastModified = types.StringValue(connector.LastModified.Format(time.RFC850))
+	}
+	if connector.CreatedAt != nil {
+		model.CreatedAt = types.StringValue(connector.CreatedAt.Format(time.RFC850))
+	} else {
+		model.CreatedAt = types.StringNull()
+	}
+	model.ProductVersion = types.StringValue(connector.ProductVersion)
+	model.Active = types.BoolPointerValue(connector.Active)
+	model.Type = types.StringValue(connector.Type)
+	model.State = types.StringPointerValue(connector.State)
+	model.VersionID = types.StringPointerValue(connector.VersionID)
+
+	switch connector.Type {
+	case "storage":
+		var attrs storageConnectorRawAttributes
+		if err := json.Unmarshal(connector.Attributes, &attrs); err == nil {
+			model.StorageAttrs = &StorageAttributesModel{
+				Bucket: types.StringValue(attrs.Bucket),
+				Prefix: types.StringPointerValue(attrs.Prefix),
+			}
+		}
+		model.HTTPAttrs = nil
+	case "http":
+		var attrs httpConnectorRawAttributes
+		if err := json.Unmarshal(connector.Attributes, &attrs); err == nil {
+			model.HTTPAttrs = populateHTTPAttrsFromRaw(model.HTTPAttrs, &attrs)
+		}
+		model.StorageAttrs = nil
+	}
+}
+
+func populateHTTPAttrsFromRaw(prior *HTTPAttributesModel, attrs *httpConnectorRawAttributes) *HTTPAttributesModel {
+	if attrs == nil {
+		return nil
+	}
+	out := &HTTPAttributesModel{
+		Addresses: populateAddressesFromRaw(attrs.Addresses),
+	}
+	if shouldPopulate(prior, func(p *HTTPAttributesModel) bool { return p.ConnectionOptions != nil }) && attrs.ConnectionOptions != nil {
+		out.ConnectionOptions = populateConnectionOptionsFromRaw(nilIfNil(prior, func(p *HTTPAttributesModel) *HTTPConnectionOptionsModel { return p.ConnectionOptions }), attrs.ConnectionOptions)
+	}
+	if shouldPopulate(prior, func(p *HTTPAttributesModel) bool { return p.Modules != nil }) && attrs.Modules != nil {
+		out.Modules = populateHTTPModulesFromRaw(nilIfNil(prior, func(p *HTTPAttributesModel) *HTTPModulesModel { return p.Modules }), attrs.Modules)
+	}
+	return out
+}
+
+func nilIfNil[T any, R any](value *T, getter func(*T) *R) *R {
+	if value == nil {
+		return nil
+	}
+	return getter(value)
+}
+
+func populateAddressesFromRaw(in []httpConnectorRawAddress) []AddressWrapperModel {
+	out := make([]AddressWrapperModel, 0, len(in))
+	for _, addr := range in {
+		addrModel := AddressModel{
+			Address:   types.StringValue(addr.Address),
+			Active:    types.BoolPointerValue(addr.Active),
+			HTTPPort:  types.Int64PointerValue(addr.HTTPPort),
+			HTTPSPort: types.Int64PointerValue(addr.HTTPSPort),
+		}
+		if addr.Modules != nil && addr.Modules.LoadBalancer != nil {
+			addrModel.Modules = &AddressModulesModel{
+				LoadBalancer: &AddressLoadBalancerModel{
+					ServerRole: types.StringPointerValue(addr.Modules.LoadBalancer.ServerRole),
+					Weight:     types.Int64PointerValue(addr.Modules.LoadBalancer.Weight),
+				},
+			}
+		}
+		out = append(out, AddressWrapperModel{Endpoint: &addrModel})
+	}
+	return out
+}
+
+func populateConnectionOptionsFromRaw(prior *HTTPConnectionOptionsModel, co *httpConnectorRawOptions) *HTTPConnectionOptionsModel {
+	out := &HTTPConnectionOptionsModel{}
+	if prior != nil {
+		*out = *prior
+	}
+	if shouldPopulate(prior, func(p *HTTPConnectionOptionsModel) bool { return !p.DNSResolution.IsNull() }) {
+		out.DNSResolution = types.StringPointerValue(co.DNSResolution)
+	}
+	if shouldPopulate(prior, func(p *HTTPConnectionOptionsModel) bool { return !p.FollowingRedirect.IsNull() }) {
+		out.FollowingRedirect = types.BoolPointerValue(co.FollowingRedirect)
+	}
+	if shouldPopulate(prior, func(p *HTTPConnectionOptionsModel) bool { return !p.Host.IsNull() }) {
+		out.Host = types.StringPointerValue(co.Host)
+	}
+	if shouldPopulate(prior, func(p *HTTPConnectionOptionsModel) bool { return !p.HTTPVersionPolicy.IsNull() }) {
+		out.HTTPVersionPolicy = types.StringPointerValue(co.HTTPVersionPolicy)
+	}
+	if shouldPopulate(prior, func(p *HTTPConnectionOptionsModel) bool { return !p.PathPrefix.IsNull() }) {
+		out.PathPrefix = types.StringPointerValue(co.PathPrefix)
+	}
+	if shouldPopulate(prior, func(p *HTTPConnectionOptionsModel) bool { return !p.RealIPHeader.IsNull() }) {
+		out.RealIPHeader = types.StringPointerValue(co.RealIPHeader)
+	}
+	if shouldPopulate(prior, func(p *HTTPConnectionOptionsModel) bool { return !p.RealPortHeader.IsNull() }) {
+		out.RealPortHeader = types.StringPointerValue(co.RealPortHeader)
+	}
+	if shouldPopulate(prior, func(p *HTTPConnectionOptionsModel) bool { return !p.TransportPolicy.IsNull() }) {
+		out.TransportPolicy = types.StringPointerValue(co.TransportPolicy)
+	}
+	return out
+}
+
+func populateHTTPModulesFromRaw(prior *HTTPModulesModel, modules *httpConnectorRawModules) *HTTPModulesModel {
+	out := &HTTPModulesModel{}
+	if shouldPopulate(prior, func(p *HTTPModulesModel) bool { return p.LoadBalancer != nil }) && modules.LoadBalancer != nil {
+		out.LoadBalancer = &LoadBalancerModuleModel{
+			Enabled: types.BoolPointerValue(modules.LoadBalancer.Enabled),
+		}
+		if shouldPopulate(nilIfNil(prior, func(p *HTTPModulesModel) *LoadBalancerModuleModel { return p.LoadBalancer }), func(p *LoadBalancerModuleModel) bool { return p.Config != nil }) && modules.LoadBalancer.Config != nil {
+			out.LoadBalancer.Config = &LoadBalancerConfigModel{
+				Method:            types.StringPointerValue(modules.LoadBalancer.Config.Method),
+				MaxRetries:        types.Int64PointerValue(modules.LoadBalancer.Config.MaxRetries),
+				ConnectionTimeout: types.Int64PointerValue(modules.LoadBalancer.Config.ConnectionTimeout),
+				ReadWriteTimeout:  types.Int64PointerValue(modules.LoadBalancer.Config.ReadWriteTimeout),
+			}
+		}
+	}
+	if shouldPopulate(prior, func(p *HTTPModulesModel) bool { return p.OriginShield != nil }) && modules.OriginShield != nil {
+		out.OriginShield = &OriginShieldModuleModel{
+			Enabled: types.BoolPointerValue(modules.OriginShield.Enabled),
+		}
+		if shouldPopulate(nilIfNil(prior, func(p *HTTPModulesModel) *OriginShieldModuleModel { return p.OriginShield }), func(p *OriginShieldModuleModel) bool { return p.Config != nil }) && modules.OriginShield.Config != nil {
+			out.OriginShield.Config = &OriginShieldConfigModel{}
+			if modules.OriginShield.Config.OriginIPAcl != nil {
+				out.OriginShield.Config.OriginIPAcl = &OriginIPAclModel{Enabled: types.BoolPointerValue(modules.OriginShield.Config.OriginIPAcl.Enabled)}
+			}
+			if modules.OriginShield.Config.Hmac != nil {
+				out.OriginShield.Config.Hmac = &HMACConfigModel{Enabled: types.BoolPointerValue(modules.OriginShield.Config.Hmac.Enabled)}
+			}
+		}
+	}
+	return out
 }
 
 // shouldPopulate returns true when prior is nil (e.g. fresh import) or when

--- a/internal/resource_firewall_functions_instance.go
+++ b/internal/resource_firewall_functions_instance.go
@@ -2,7 +2,7 @@ package provider
 
 import (
 	"context"
-	"io"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -36,11 +36,11 @@ type FirewallFunctionsInstanceResource struct {
 }
 
 type FirewallFunctionInstanceResourceModel struct {
-	State       types.String                         `tfsdk:"state"`
-	Data        FirewallFunctionInstanceResourceData `tfsdk:"data"`
-	ID          types.String                         `tfsdk:"id"`
-	FirewallID  types.Int64                          `tfsdk:"firewall_id"`
-	LastUpdated types.String                         `tfsdk:"last_updated"`
+	State       types.String                          `tfsdk:"state"`
+	Data        *FirewallFunctionInstanceResourceData `tfsdk:"data"`
+	ID          types.String                          `tfsdk:"id"`
+	FirewallID  types.Int64                           `tfsdk:"firewall_id"`
+	LastUpdated types.String                          `tfsdk:"last_updated"`
 }
 
 type FirewallFunctionInstanceResourceData struct {
@@ -181,7 +181,7 @@ func (r *FirewallFunctionsInstanceResource) Create(ctx context.Context, req reso
 		FirewallFunctionInstanceRequest(functionInstanceRequest).
 		Execute() //nolint
 	if err != nil {
-		if response.StatusCode == 429 {
+		if response != nil && response.StatusCode == 429 {
 			functionInstanceResponse, response, err = utils.RetryOn429(func() (*sdk.FirewallFunctionInstanceResponse, *http.Response, error) {
 				return r.client.api.FirewallsFunctionAPI.
 					CreateFirewallFunction(ctx, firewallID.ValueInt64()).
@@ -201,14 +201,7 @@ func (r *FirewallFunctionsInstanceResource) Create(ctx context.Context, req reso
 				return
 			}
 		} else {
-			bodyBytes, errReadAll := io.ReadAll(response.Body)
-			if errReadAll != nil {
-				resp.Diagnostics.AddError(
-					errReadAll.Error(),
-					"err",
-				)
-			}
-			bodyString := string(bodyBytes)
+			bodyString := readAPIErrorBody(response)
 			resp.Diagnostics.AddError(
 				err.Error(),
 				bodyString,
@@ -228,7 +221,7 @@ func (r *FirewallFunctionsInstanceResource) Create(ctx context.Context, req reso
 		return
 	}
 
-	plan.Data = FirewallFunctionInstanceResourceData{
+	plan.Data = &FirewallFunctionInstanceResourceData{
 		Name:         types.StringValue(functionInstanceResponse.Data.GetName()),
 		Args:         types.StringValue(jsonArgsStr),
 		Function:     types.Int64Value(functionInstanceResponse.Data.GetFunction()),
@@ -266,7 +259,9 @@ func (r *FirewallFunctionsInstanceResource) Read(ctx context.Context, req resour
 		functionInstanceID, _ = strconv.ParseInt(valueFromCmd[1], 10, 64)
 	} else {
 		firewallID = state.FirewallID.ValueInt64()
-		functionInstanceID = state.Data.ID.ValueInt64()
+		if state.Data != nil {
+			functionInstanceID = state.Data.ID.ValueInt64()
+		}
 	}
 
 	if functionInstanceID == 0 {
@@ -281,11 +276,11 @@ func (r *FirewallFunctionsInstanceResource) Read(ctx context.Context, req resour
 		api.FirewallsFunctionAPI.
 		RetrieveFirewallFunction(ctx, firewallID, functionInstanceID).Execute() //nolint
 	if err != nil {
-		if response.StatusCode == http.StatusNotFound {
+		if response != nil && response.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		if response.StatusCode == 429 {
+		if response != nil && response.StatusCode == 429 {
 			functionInstanceResponse, response, err = utils.RetryOn429(func() (*sdk.FirewallFunctionInstanceResponse, *http.Response, error) {
 				return r.client.
 					api.FirewallsFunctionAPI.
@@ -304,14 +299,7 @@ func (r *FirewallFunctionsInstanceResource) Read(ctx context.Context, req resour
 				return
 			}
 		} else {
-			bodyBytes, errReadAll := io.ReadAll(response.Body)
-			if errReadAll != nil {
-				resp.Diagnostics.AddError(
-					errReadAll.Error(),
-					"err",
-				)
-			}
-			bodyString := string(bodyBytes)
+			bodyString := readAPIErrorBody(response)
 			resp.Diagnostics.AddError(
 				err.Error(),
 				bodyString,
@@ -333,8 +321,8 @@ func (r *FirewallFunctionsInstanceResource) Read(ctx context.Context, req resour
 	readState := FirewallFunctionInstanceResourceModel{
 		FirewallID: types.Int64Value(firewallID),
 		State:      types.StringValue(stateValue),
-		ID:         types.StringValue(strconv.FormatInt(functionInstanceResponse.Data.GetId(), 10)),
-		Data: FirewallFunctionInstanceResourceData{
+		ID:         types.StringValue(fmt.Sprintf("%d/%d", firewallID, functionInstanceResponse.Data.GetId())),
+		Data: &FirewallFunctionInstanceResourceData{
 			ID:           types.Int64Value(functionInstanceResponse.Data.GetId()),
 			LastEditor:   types.StringValue(functionInstanceResponse.Data.GetLastEditor()),
 			LastModified: types.StringValue(functionInstanceResponse.Data.GetLastModified().Format(time.RFC850)),
@@ -411,7 +399,7 @@ func (r *FirewallFunctionsInstanceResource) Update(ctx context.Context, req reso
 		PatchedFirewallFunctionInstanceRequest(patchRequest).
 		Execute() //nolint
 	if err != nil {
-		if response.StatusCode == 429 {
+		if response != nil && response.StatusCode == 429 {
 			updateResponse, response, err = utils.RetryOn429(func() (*sdk.FirewallFunctionInstanceResponse, *http.Response, error) {
 				return r.client.api.FirewallsFunctionAPI.
 					PartialUpdateFirewallFunction(ctx, firewallID.ValueInt64(), functionInstanceID.ValueInt64()).
@@ -431,14 +419,7 @@ func (r *FirewallFunctionsInstanceResource) Update(ctx context.Context, req reso
 				return
 			}
 		} else {
-			bodyBytes, errReadAll := io.ReadAll(response.Body)
-			if errReadAll != nil {
-				resp.Diagnostics.AddError(
-					errReadAll.Error(),
-					"err",
-				)
-			}
-			bodyString := string(bodyBytes)
+			bodyString := readAPIErrorBody(response)
 			resp.Diagnostics.AddError(
 				err.Error(),
 				bodyString,
@@ -458,7 +439,7 @@ func (r *FirewallFunctionsInstanceResource) Update(ctx context.Context, req reso
 		return
 	}
 
-	plan.Data = FirewallFunctionInstanceResourceData{
+	plan.Data = &FirewallFunctionInstanceResourceData{
 		Function:     types.Int64Value(updateResponse.Data.GetFunction()),
 		Name:         types.StringValue(updateResponse.Data.GetName()),
 		LastEditor:   types.StringValue(updateResponse.Data.GetLastEditor()),
@@ -517,14 +498,7 @@ func (r *FirewallFunctionsInstanceResource) Delete(ctx context.Context, req reso
 		if response != nil && response.StatusCode == http.StatusNotFound {
 			return
 		}
-		bodyBytes, errReadAll := io.ReadAll(response.Body)
-		if errReadAll != nil {
-			resp.Diagnostics.AddError(
-				errReadAll.Error(),
-				"err",
-			)
-		}
-		bodyString := string(bodyBytes)
+		bodyString := readAPIErrorBody(response)
 		resp.Diagnostics.AddError(
 			err.Error(),
 			bodyString,
@@ -534,5 +508,35 @@ func (r *FirewallFunctionsInstanceResource) Delete(ctx context.Context, req reso
 }
 
 func (r *FirewallFunctionsInstanceResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	parts := strings.Split(req.ID, "/")
+	if len(parts) != 2 {
+		resp.Diagnostics.AddError(
+			"Invalid import format",
+			"Expected format: firewallID/functionInstanceID",
+		)
+		return
+	}
+
+	firewallID, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid firewall ID format", err.Error())
+		return
+	}
+
+	functionInstanceID, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid function instance ID format", err.Error())
+		return
+	}
+
+	state := FirewallFunctionInstanceResourceModel{
+		FirewallID: types.Int64Value(firewallID),
+		ID:         types.StringValue(fmt.Sprintf("%d/%d", firewallID, functionInstanceID)),
+		Data: &FirewallFunctionInstanceResourceData{
+			ID: types.Int64Value(functionInstanceID),
+		},
+	}
+
+	diags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
 }

--- a/internal/resource_firewall_main_setting.go
+++ b/internal/resource_firewall_main_setting.go
@@ -2,14 +2,12 @@ package provider
 
 import (
 	"context"
-	"io"
 	"net/http"
 	"strconv"
 	"time"
 
 	sdk "github.com/aziontech/azionapi-v4-go-sdk-dev/azion-api"
 	"github.com/aziontech/terraform-provider-azion/internal/utils"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -216,7 +214,7 @@ func (r *firewallResource) Create(ctx context.Context, req resource.CreateReques
 
 	firewallResponse, response, err := r.client.api.FirewallsAPI.CreateFirewall(ctx).FirewallRequest(firewallRequest).Execute() //nolint
 	if err != nil {
-		if response.StatusCode == 429 {
+		if response != nil && response.StatusCode == 429 {
 			firewallResponse, response, err = utils.RetryOn429(func() (*sdk.FirewallResponse, *http.Response, error) {
 				return r.client.api.FirewallsAPI.CreateFirewall(ctx).FirewallRequest(firewallRequest).Execute() //nolint
 			}, 5) // Maximum 5 retries
@@ -233,14 +231,7 @@ func (r *firewallResource) Create(ctx context.Context, req resource.CreateReques
 				return
 			}
 		} else {
-			bodyBytes, errReadAll := io.ReadAll(response.Body)
-			if errReadAll != nil {
-				resp.Diagnostics.AddError(
-					errReadAll.Error(),
-					"err",
-				)
-			}
-			bodyString := string(bodyBytes)
+			bodyString := readAPIErrorBody(response)
 			resp.Diagnostics.AddError(
 				err.Error(),
 				bodyString,
@@ -316,6 +307,10 @@ func (r *firewallResource) Read(ctx context.Context, req resource.ReadRequest, r
 	}
 	var firewallID int64
 	if state.ID.IsNull() {
+		if state.Firewall == nil || state.Firewall.ID.IsNull() {
+			resp.Diagnostics.AddError("Failed to parse firewall ID", "Firewall ID cannot be empty")
+			return
+		}
 		firewallID = state.Firewall.ID.ValueInt64()
 	} else {
 		var err error
@@ -329,11 +324,11 @@ func (r *firewallResource) Read(ctx context.Context, req resource.ReadRequest, r
 	firewallResponse, response, err := r.client.api.FirewallsAPI.
 		RetrieveFirewall(ctx, firewallID).Execute() //nolint
 	if err != nil {
-		if response.StatusCode == http.StatusNotFound {
+		if response != nil && response.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		if response.StatusCode == 429 {
+		if response != nil && response.StatusCode == 429 {
 			firewallResponse, response, err = utils.RetryOn429(func() (*sdk.FirewallResponse, *http.Response, error) {
 				return r.client.api.FirewallsAPI.RetrieveFirewall(ctx, firewallID).Execute() //nolint
 			}, 5) // Maximum 5 retries
@@ -350,14 +345,7 @@ func (r *firewallResource) Read(ctx context.Context, req resource.ReadRequest, r
 				return
 			}
 		} else {
-			bodyBytes, errReadAll := io.ReadAll(response.Body)
-			if errReadAll != nil {
-				resp.Diagnostics.AddError(
-					errReadAll.Error(),
-					"err",
-				)
-			}
-			bodyString := string(bodyBytes)
+			bodyString := readAPIErrorBody(response)
 			resp.Diagnostics.AddError(
 				err.Error(),
 				bodyString,
@@ -445,6 +433,10 @@ func (r *firewallResource) Update(ctx context.Context, req resource.UpdateReques
 
 	var firewallID int64
 	if state.ID.IsNull() {
+		if state.Firewall == nil || state.Firewall.ID.IsNull() {
+			resp.Diagnostics.AddError("Failed to parse firewall ID", "Firewall ID cannot be empty")
+			return
+		}
 		firewallID = state.Firewall.ID.ValueInt64()
 	} else {
 		var err error
@@ -483,7 +475,7 @@ func (r *firewallResource) Update(ctx context.Context, req resource.UpdateReques
 
 	firewallResponse, response, err := r.client.api.FirewallsAPI.PartialUpdateFirewall(ctx, firewallID).PatchedFirewallRequest(firewallRequest).Execute() //nolint
 	if err != nil {
-		if response.StatusCode == 429 {
+		if response != nil && response.StatusCode == 429 {
 			firewallResponse, response, err = utils.RetryOn429(func() (*sdk.FirewallResponse, *http.Response, error) {
 				return r.client.api.FirewallsAPI.PartialUpdateFirewall(ctx, firewallID).PatchedFirewallRequest(firewallRequest).Execute() //nolint
 			}, 5) // Maximum 5 retries
@@ -500,14 +492,7 @@ func (r *firewallResource) Update(ctx context.Context, req resource.UpdateReques
 				return
 			}
 		} else {
-			bodyBytes, errReadAll := io.ReadAll(response.Body)
-			if errReadAll != nil {
-				resp.Diagnostics.AddError(
-					errReadAll.Error(),
-					"err",
-				)
-			}
-			bodyString := string(bodyBytes)
+			bodyString := readAPIErrorBody(response)
 			resp.Diagnostics.AddError(
 				err.Error(),
 				bodyString,
@@ -585,6 +570,10 @@ func (r *firewallResource) Delete(ctx context.Context, req resource.DeleteReques
 
 	var firewallID int64
 	if state.ID.IsNull() {
+		if state.Firewall == nil || state.Firewall.ID.IsNull() {
+			resp.Diagnostics.AddError("Failed to parse firewall ID", "Firewall ID cannot be empty")
+			return
+		}
 		firewallID = state.Firewall.ID.ValueInt64()
 	} else {
 		var err error
@@ -605,14 +594,7 @@ func (r *firewallResource) Delete(ctx context.Context, req resource.DeleteReques
 		if response != nil && response.StatusCode == http.StatusNotFound {
 			return
 		}
-		bodyBytes, errReadAll := io.ReadAll(response.Body)
-		if errReadAll != nil {
-			resp.Diagnostics.AddError(
-				errReadAll.Error(),
-				"err",
-			)
-		}
-		bodyString := string(bodyBytes)
+		bodyString := readAPIErrorBody(response)
 		resp.Diagnostics.AddError(
 			err.Error(),
 			bodyString,
@@ -622,5 +604,19 @@ func (r *firewallResource) Delete(ctx context.Context, req resource.DeleteReques
 }
 
 func (r *firewallResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	firewallID, err := strconv.ParseInt(req.ID, 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid firewall ID format", err.Error())
+		return
+	}
+
+	state := FirewallResourceModel{
+		ID: types.StringValue(req.ID),
+		Firewall: &FirewallResourceResults{
+			ID: types.Int64Value(firewallID),
+		},
+	}
+
+	diags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
 }

--- a/internal/resource_function.go
+++ b/internal/resource_function.go
@@ -2,14 +2,12 @@ package provider
 
 import (
 	"context"
-	"io"
 	"net/http"
 	"strconv"
 	"time"
 
 	azionapi "github.com/aziontech/azionapi-v4-go-sdk-dev/azion-api"
 	"github.com/aziontech/terraform-provider-azion/internal/utils"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -198,7 +196,7 @@ func (r *functionResource) Create(ctx context.Context, req resource.CreateReques
 
 	createFunction, response, err := r.client.api.FunctionsAPI.CreateFunction(ctx).FunctionsRequest(edgeFunction).Execute() //nolint
 	if err != nil {
-		if response.StatusCode == 429 {
+		if response != nil && response.StatusCode == 429 {
 			createFunction, response, err = utils.RetryOn429(func() (*azionapi.FunctionResponse, *http.Response, error) {
 				return r.client.api.FunctionsAPI.CreateFunction(ctx).FunctionsRequest(edgeFunction).Execute() //nolint
 			}, 5) // Maximum 5 retries
@@ -215,14 +213,7 @@ func (r *functionResource) Create(ctx context.Context, req resource.CreateReques
 				return
 			}
 		} else {
-			bodyBytes, errReadAll := io.ReadAll(response.Body)
-			if errReadAll != nil {
-				resp.Diagnostics.AddError(
-					errReadAll.Error(),
-					"err",
-				)
-			}
-			bodyString := string(bodyBytes)
+			bodyString := readAPIErrorBody(response)
 			resp.Diagnostics.AddError(
 				err.Error(),
 				bodyString,
@@ -298,11 +289,11 @@ func (r *functionResource) Read(ctx context.Context, req resource.ReadRequest, r
 
 	getFunction, response, err := r.client.api.FunctionsAPI.RetrieveFunction(ctx, functionId).Execute() //nolint
 	if err != nil {
-		if response.StatusCode == http.StatusNotFound {
+		if response != nil && response.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		if response.StatusCode == 429 {
+		if response != nil && response.StatusCode == 429 {
 			getFunction, response, err = utils.RetryOn429(func() (*azionapi.FunctionResponse, *http.Response, error) {
 				return r.client.api.FunctionsAPI.RetrieveFunction(ctx, functionId).Execute() //nolint
 			}, 5) // Maximum 5 retries
@@ -319,14 +310,7 @@ func (r *functionResource) Read(ctx context.Context, req resource.ReadRequest, r
 				return
 			}
 		} else {
-			bodyBytes, errReadAll := io.ReadAll(response.Body)
-			if errReadAll != nil {
-				resp.Diagnostics.AddError(
-					errReadAll.Error(),
-					"err",
-				)
-			}
-			bodyString := string(bodyBytes)
+			bodyString := readAPIErrorBody(response)
 			resp.Diagnostics.AddError(
 				err.Error(),
 				bodyString,
@@ -442,7 +426,7 @@ func (r *functionResource) Update(ctx context.Context, req resource.UpdateReques
 
 	updateFunction, response, err := r.client.api.FunctionsAPI.PartialUpdateFunction(ctx, functionId).PatchedFunctionsRequest(updateFunctionRequest).Execute() //nolint
 	if err != nil {
-		if response.StatusCode == 429 {
+		if response != nil && response.StatusCode == 429 {
 			updateFunction, response, err = utils.RetryOn429(func() (*azionapi.FunctionResponse, *http.Response, error) {
 				return r.client.api.FunctionsAPI.PartialUpdateFunction(ctx, functionId).PatchedFunctionsRequest(updateFunctionRequest).Execute() //nolint
 			}, 5) // Maximum 5 retries
@@ -459,14 +443,7 @@ func (r *functionResource) Update(ctx context.Context, req resource.UpdateReques
 				return
 			}
 		} else {
-			bodyBytes, errReadAll := io.ReadAll(response.Body)
-			if errReadAll != nil {
-				resp.Diagnostics.AddError(
-					errReadAll.Error(),
-					"err",
-				)
-			}
-			bodyString := string(bodyBytes)
+			bodyString := readAPIErrorBody(response)
 			resp.Diagnostics.AddError(
 				err.Error(),
 				bodyString,
@@ -550,14 +527,7 @@ func (r *functionResource) Delete(ctx context.Context, req resource.DeleteReques
 		if response != nil && response.StatusCode == http.StatusNotFound {
 			return
 		}
-		bodyBytes, errReadAll := io.ReadAll(response.Body)
-		if errReadAll != nil {
-			resp.Diagnostics.AddError(
-				errReadAll.Error(),
-				"err",
-			)
-		}
-		bodyString := string(bodyBytes)
+		bodyString := readAPIErrorBody(response)
 		resp.Diagnostics.AddError(
 			err.Error(),
 			bodyString,
@@ -567,5 +537,19 @@ func (r *functionResource) Delete(ctx context.Context, req resource.DeleteReques
 }
 
 func (r *functionResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	functionID, err := strconv.ParseInt(req.ID, 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid function ID format", err.Error())
+		return
+	}
+
+	state := functionResourceModel{
+		ID: types.StringValue(req.ID),
+		Function: &functionResourceResults{
+			ID: types.Int64Value(functionID),
+		},
+	}
+
+	diags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
 }

--- a/internal/resource_network_list.go
+++ b/internal/resource_network_list.go
@@ -2,14 +2,12 @@ package provider
 
 import (
 	"context"
-	"io"
 	"net/http"
 	"strconv"
 	"time"
 
 	azionapi "github.com/aziontech/azionapi-v4-go-sdk-dev/azion-api"
 	"github.com/aziontech/terraform-provider-azion/internal/utils"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -164,25 +162,8 @@ func (r *networkListResource) Create(ctx context.Context, req resource.CreateReq
 				return
 			}
 		} else {
-			if response != nil && response.Body != nil {
-				bodyBytes, errReadAll := io.ReadAll(response.Body)
-				if errReadAll != nil {
-					resp.Diagnostics.AddError(
-						errReadAll.Error(),
-						"error reading response from API",
-					)
-				}
-				bodyString := string(bodyBytes)
-				resp.Diagnostics.AddError(
-					err.Error(),
-					bodyString,
-				)
-			} else {
-				resp.Diagnostics.AddError(
-					err.Error(),
-					"API request failed",
-				)
-			}
+			bodyString := readAPIErrorBody(response)
+			resp.Diagnostics.AddError(err.Error(), bodyString)
 			return
 		}
 	}
@@ -227,6 +208,10 @@ func (r *networkListResource) Read(ctx context.Context, req resource.ReadRequest
 
 	var networkListId int64
 	if state.ID.IsNull() {
+		if state.NetworkList == nil || state.NetworkList.ID.IsNull() {
+			resp.Diagnostics.AddError("Invalid ID format", "Network list ID cannot be empty")
+			return
+		}
 		networkListId = state.NetworkList.ID.ValueInt64()
 	} else {
 		id, err := strconv.ParseInt(state.ID.ValueString(), 10, 64)
@@ -263,25 +248,8 @@ func (r *networkListResource) Read(ctx context.Context, req resource.ReadRequest
 				return
 			}
 		} else {
-			if response != nil && response.Body != nil {
-				bodyBytes, errReadAll := io.ReadAll(response.Body)
-				if errReadAll != nil {
-					resp.Diagnostics.AddError(
-						errReadAll.Error(),
-						"error reading response from API",
-					)
-				}
-				bodyString := string(bodyBytes)
-				resp.Diagnostics.AddError(
-					err.Error(),
-					bodyString,
-				)
-			} else {
-				resp.Diagnostics.AddError(
-					err.Error(),
-					"API request failed",
-				)
-			}
+			bodyString := readAPIErrorBody(response)
+			resp.Diagnostics.AddError(err.Error(), bodyString)
 			return
 		}
 	}
@@ -332,6 +300,10 @@ func (r *networkListResource) Update(ctx context.Context, req resource.UpdateReq
 
 	var networkListId int64
 	if state.ID.IsNull() {
+		if state.NetworkList == nil || state.NetworkList.ID.IsNull() {
+			resp.Diagnostics.AddError("Invalid ID format", "Network list ID cannot be empty")
+			return
+		}
 		networkListId = state.NetworkList.ID.ValueInt64()
 	} else {
 		id, err := strconv.ParseInt(state.ID.ValueString(), 10, 64)
@@ -377,25 +349,8 @@ func (r *networkListResource) Update(ctx context.Context, req resource.UpdateReq
 				return
 			}
 		} else {
-			if response != nil && response.Body != nil {
-				bodyBytes, errReadAll := io.ReadAll(response.Body)
-				if errReadAll != nil {
-					resp.Diagnostics.AddError(
-						errReadAll.Error(),
-						"error reading response from API",
-					)
-				}
-				bodyString := string(bodyBytes)
-				resp.Diagnostics.AddError(
-					err.Error(),
-					bodyString,
-				)
-			} else {
-				resp.Diagnostics.AddError(
-					err.Error(),
-					"API request failed",
-				)
-			}
+			bodyString := readAPIErrorBody(response)
+			resp.Diagnostics.AddError(err.Error(), bodyString)
 			return
 		}
 	}
@@ -440,6 +395,10 @@ func (r *networkListResource) Delete(ctx context.Context, req resource.DeleteReq
 
 	var networkListId int64
 	if state.ID.IsNull() {
+		if state.NetworkList == nil || state.NetworkList.ID.IsNull() {
+			resp.Diagnostics.AddError("Invalid ID format", "Network list ID cannot be empty")
+			return
+		}
 		networkListId = state.NetworkList.ID.ValueInt64()
 	} else {
 		id, err := strconv.ParseInt(state.ID.ValueString(), 10, 64)
@@ -463,29 +422,27 @@ func (r *networkListResource) Delete(ctx context.Context, req resource.DeleteReq
 		if response != nil && response.StatusCode == http.StatusNotFound {
 			return
 		}
-		if response != nil && response.Body != nil {
-			bodyBytes, errReadAll := io.ReadAll(response.Body)
-			if errReadAll != nil {
-				resp.Diagnostics.AddError(
-					errReadAll.Error(),
-					"error reading response from API",
-				)
-			}
-			bodyString := string(bodyBytes)
-			resp.Diagnostics.AddError(
-				err.Error(),
-				bodyString,
-			)
-		} else {
-			resp.Diagnostics.AddError(
-				err.Error(),
-				"API request failed",
-			)
-		}
+		bodyString := readAPIErrorBody(response)
+		resp.Diagnostics.AddError(err.Error(), bodyString)
 		return
 	}
 }
 
 func (r *networkListResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	networkListID, err := strconv.ParseInt(req.ID, 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid network list ID format", err.Error())
+		return
+	}
+
+	state := NetworkListResourceModel{
+		ID: types.StringValue(req.ID),
+		NetworkList: &NetworkListResourceResults{
+			ID:    types.Int64Value(networkListID),
+			Items: types.SetNull(types.StringType),
+		},
+	}
+
+	diags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
 }

--- a/internal/resource_record.go
+++ b/internal/resource_record.go
@@ -11,7 +11,6 @@ import (
 
 	azionapi "github.com/aziontech/azionapi-v4-go-sdk-dev/azion-api"
 	"github.com/aziontech/terraform-provider-azion/internal/utils"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -421,7 +420,30 @@ func (r *recordResource) Delete(ctx context.Context, req resource.DeleteRequest,
 }
 
 func (r *recordResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("zone_id"), req, resp)
+	parts := strings.Split(req.ID, "/")
+	if len(parts) != 2 {
+		resp.Diagnostics.AddError(
+			"Invalid import format",
+			"Expected format: zoneID/recordID",
+		)
+		return
+	}
+
+	recordID, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid record ID format", err.Error())
+		return
+	}
+
+	state := recordResourceModel{
+		ZoneId: types.StringValue(parts[0]),
+		Record: &recordModel{
+			Id: types.Int64Value(recordID),
+		},
+	}
+
+	diags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
 }
 
 // buildRdataList converts a slice of types.String to a slice of string.

--- a/internal/resource_waf.go
+++ b/internal/resource_waf.go
@@ -2,14 +2,12 @@ package provider
 
 import (
 	"context"
-	"io"
 	"net/http"
 	"strconv"
 	"time"
 
 	azionapi "github.com/aziontech/azionapi-v4-go-sdk-dev/azion-api"
 	"github.com/aziontech/terraform-provider-azion/internal/utils"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -213,7 +211,7 @@ func (r *wafResource) Create(ctx context.Context, req resource.CreateRequest, re
 	// Create the WAF.
 	wafResponse, response, err := r.client.api.WAFsAPI.CreateWaf(ctx).WAFRequest(*wafRequest).Execute()
 	if err != nil {
-		if response.StatusCode == 429 {
+		if response != nil && response.StatusCode == 429 {
 			wafResponse, response, err = utils.RetryOn429(func() (*azionapi.WAFResponse, *http.Response, error) {
 				return r.client.api.WAFsAPI.CreateWaf(ctx).WAFRequest(*wafRequest).Execute()
 			}, 5)
@@ -230,14 +228,7 @@ func (r *wafResource) Create(ctx context.Context, req resource.CreateRequest, re
 				return
 			}
 		} else {
-			bodyBytes, errReadAll := io.ReadAll(response.Body)
-			if errReadAll != nil {
-				resp.Diagnostics.AddError(
-					errReadAll.Error(),
-					"err",
-				)
-			}
-			bodyString := string(bodyBytes)
+			bodyString := readAPIErrorBody(response)
 			resp.Diagnostics.AddError(
 				err.Error(),
 				bodyString,
@@ -278,11 +269,21 @@ func (r *wafResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 	}
 
 	// Save the state's engine_settings to preserve it if it was null.
-	stateEngineSettings := state.Result.EngineSettings
+	var stateEngineSettings *WafEngineSettingsResourceModel
+	if state.Result != nil {
+		stateEngineSettings = state.Result.EngineSettings
+	}
 
 	var wafID int64
 	var err error
 	if state.ID.IsNull() {
+		if state.Result == nil || state.Result.ID.IsNull() {
+			resp.Diagnostics.AddError(
+				"WAF ID error",
+				"WAF ID cannot be empty",
+			)
+			return
+		}
 		wafID = state.Result.ID.ValueInt64()
 	} else {
 		wafID, err = strconv.ParseInt(state.ID.ValueString(), 10, 64)
@@ -297,11 +298,11 @@ func (r *wafResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 
 	wafResponse, response, err := r.client.api.WAFsAPI.RetrieveWaf(ctx, wafID).Execute()
 	if err != nil {
-		if response.StatusCode == http.StatusNotFound {
+		if response != nil && response.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		if response.StatusCode == 429 {
+		if response != nil && response.StatusCode == 429 {
 			wafResponse, response, err = utils.RetryOn429(func() (*azionapi.WAFResponse, *http.Response, error) {
 				return r.client.api.WAFsAPI.RetrieveWaf(ctx, wafID).Execute()
 			}, 5)
@@ -318,14 +319,7 @@ func (r *wafResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 				return
 			}
 		} else {
-			bodyBytes, errReadAll := io.ReadAll(response.Body)
-			if errReadAll != nil {
-				resp.Diagnostics.AddError(
-					errReadAll.Error(),
-					"err",
-				)
-			}
-			bodyString := string(bodyBytes)
+			bodyString := readAPIErrorBody(response)
 			resp.Diagnostics.AddError(
 				err.Error(),
 				bodyString,
@@ -373,6 +367,13 @@ func (r *wafResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	var wafID int64
 	var err error
 	if state.ID.IsNull() {
+		if state.Result == nil || state.Result.ID.IsNull() {
+			resp.Diagnostics.AddError(
+				"WAF ID error",
+				"WAF ID cannot be empty",
+			)
+			return
+		}
 		wafID = state.Result.ID.ValueInt64()
 	} else {
 		wafID, err = strconv.ParseInt(state.ID.ValueString(), 10, 64)
@@ -405,7 +406,7 @@ func (r *wafResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	// Update the WAF.
 	wafResponse, response, err := r.client.api.WAFsAPI.UpdateWaf(ctx, wafID).WAFRequest(*wafRequest).Execute()
 	if err != nil {
-		if response.StatusCode == 429 {
+		if response != nil && response.StatusCode == 429 {
 			wafResponse, response, err = utils.RetryOn429(func() (*azionapi.WAFResponse, *http.Response, error) {
 				return r.client.api.WAFsAPI.UpdateWaf(ctx, wafID).WAFRequest(*wafRequest).Execute()
 			}, 5)
@@ -422,14 +423,7 @@ func (r *wafResource) Update(ctx context.Context, req resource.UpdateRequest, re
 				return
 			}
 		} else {
-			bodyBytes, errReadAll := io.ReadAll(response.Body)
-			if errReadAll != nil {
-				resp.Diagnostics.AddError(
-					errReadAll.Error(),
-					"err",
-				)
-			}
-			bodyString := string(bodyBytes)
+			bodyString := readAPIErrorBody(response)
 			resp.Diagnostics.AddError(
 				err.Error(),
 				bodyString,
@@ -472,6 +466,13 @@ func (r *wafResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 	var wafID int64
 	var err error
 	if state.ID.IsNull() {
+		if state.Result == nil || state.Result.ID.IsNull() {
+			resp.Diagnostics.AddError(
+				"WAF ID error",
+				"WAF ID cannot be empty",
+			)
+			return
+		}
 		wafID = state.Result.ID.ValueInt64()
 	} else {
 		wafID, err = strconv.ParseInt(state.ID.ValueString(), 10, 64)
@@ -495,14 +496,7 @@ func (r *wafResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 		if response != nil && response.StatusCode == http.StatusNotFound {
 			return
 		}
-		bodyBytes, errReadAll := io.ReadAll(response.Body)
-		if errReadAll != nil {
-			resp.Diagnostics.AddError(
-				errReadAll.Error(),
-				"err",
-			)
-		}
-		bodyString := string(bodyBytes)
+		bodyString := readAPIErrorBody(response)
 		resp.Diagnostics.AddError(
 			err.Error(),
 			bodyString,
@@ -512,7 +506,21 @@ func (r *wafResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 }
 
 func (r *wafResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	wafID, err := strconv.ParseInt(req.ID, 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid WAF ID format", err.Error())
+		return
+	}
+
+	state := WafResourceModel{
+		ID: types.StringValue(req.ID),
+		Result: &WafResourceResults{
+			ID: types.Int64Value(wafID),
+		},
+	}
+
+	diags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
 }
 
 // buildWAFEngineSettingsRequest builds a WAFEngineSettingsFieldRequest from the Terraform model.

--- a/internal/resource_waf_rule_set.go
+++ b/internal/resource_waf_rule_set.go
@@ -2,14 +2,14 @@ package provider
 
 import (
 	"context"
-	"io"
+	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	azionapi "github.com/aziontech/azionapi-v4-go-sdk-dev/azion-api"
 	"github.com/aziontech/terraform-provider-azion/internal/utils"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -185,7 +185,7 @@ func (r *wafRuleSetResource) Create(ctx context.Context, req resource.CreateRequ
 	// Create the WAF exception.
 	exceptionResponse, response, err := r.client.api.WAFsExceptionsAPI.CreateWafException(ctx, plan.WafID.ValueInt64()).WAFRuleRequest(*wafRuleRequest).Execute()
 	if err != nil {
-		if response.StatusCode == 429 {
+		if response != nil && response.StatusCode == 429 {
 			exceptionResponse, response, err = utils.RetryOn429(func() (*azionapi.WAFRuleResponse, *http.Response, error) {
 				return r.client.api.WAFsExceptionsAPI.CreateWafException(ctx, plan.WafID.ValueInt64()).WAFRuleRequest(*wafRuleRequest).Execute()
 			}, 5)
@@ -202,14 +202,7 @@ func (r *wafRuleSetResource) Create(ctx context.Context, req resource.CreateRequ
 				return
 			}
 		} else {
-			bodyBytes, errReadAll := io.ReadAll(response.Body)
-			if errReadAll != nil {
-				resp.Diagnostics.AddError(
-					errReadAll.Error(),
-					"err",
-				)
-			}
-			bodyString := string(bodyBytes)
+			bodyString := readAPIErrorBody(response)
 			resp.Diagnostics.AddError(
 				err.Error(),
 				bodyString,
@@ -244,9 +237,21 @@ func (r *wafRuleSetResource) Read(ctx context.Context, req resource.ReadRequest,
 	}
 
 	var exceptionID int64
+	wafID := state.WafID.ValueInt64()
 	var err error
 	if state.ID.IsNull() {
 		exceptionID = state.Result.ID.ValueInt64()
+	} else if parts := strings.Split(state.ID.ValueString(), "/"); len(parts) == 2 {
+		wafID, err = strconv.ParseInt(parts[0], 10, 64)
+		if err != nil {
+			resp.Diagnostics.AddError("Value Conversion error ", "Could not convert WAF ID")
+			return
+		}
+		exceptionID, err = strconv.ParseInt(parts[1], 10, 64)
+		if err != nil {
+			resp.Diagnostics.AddError("Value Conversion error ", "Could not convert WAF Rule Set ID")
+			return
+		}
 	} else {
 		exceptionID, err = strconv.ParseInt(state.ID.ValueString(), 10, 64)
 		if err != nil {
@@ -258,15 +263,15 @@ func (r *wafRuleSetResource) Read(ctx context.Context, req resource.ReadRequest,
 		}
 	}
 
-	exceptionResponse, response, err := r.client.api.WAFsExceptionsAPI.RetrieveWafException(ctx, exceptionID, state.WafID.ValueInt64()).Execute()
+	exceptionResponse, response, err := r.client.api.WAFsExceptionsAPI.RetrieveWafException(ctx, exceptionID, wafID).Execute()
 	if err != nil {
-		if response.StatusCode == http.StatusNotFound {
+		if response != nil && response.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		if response.StatusCode == 429 {
+		if response != nil && response.StatusCode == 429 {
 			exceptionResponse, response, err = utils.RetryOn429(func() (*azionapi.WAFRuleResponse, *http.Response, error) {
-				return r.client.api.WAFsExceptionsAPI.RetrieveWafException(ctx, exceptionID, state.WafID.ValueInt64()).Execute()
+				return r.client.api.WAFsExceptionsAPI.RetrieveWafException(ctx, exceptionID, wafID).Execute()
 			}, 5)
 
 			if response != nil {
@@ -281,14 +286,7 @@ func (r *wafRuleSetResource) Read(ctx context.Context, req resource.ReadRequest,
 				return
 			}
 		} else {
-			bodyBytes, errReadAll := io.ReadAll(response.Body)
-			if errReadAll != nil {
-				resp.Diagnostics.AddError(
-					errReadAll.Error(),
-					"err",
-				)
-			}
-			bodyString := string(bodyBytes)
+			bodyString := readAPIErrorBody(response)
 			resp.Diagnostics.AddError(
 				err.Error(),
 				bodyString,
@@ -303,7 +301,8 @@ func (r *wafRuleSetResource) Read(ctx context.Context, req resource.ReadRequest,
 
 	data := exceptionResponse.GetData()
 	state.Result = transformWAFRuleToResourceModel(data)
-	state.ID = types.StringValue(strconv.FormatInt(exceptionID, 10))
+	state.WafID = types.Int64Value(wafID)
+	state.ID = types.StringValue(fmt.Sprintf("%d/%d", wafID, data.GetId()))
 
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -368,7 +367,7 @@ func (r *wafRuleSetResource) Update(ctx context.Context, req resource.UpdateRequ
 	// Update the WAF exception.
 	exceptionResponse, response, err := r.client.api.WAFsExceptionsAPI.UpdateWafException(ctx, exceptionID, plan.WafID.ValueInt64()).WAFRuleRequest(*wafRuleRequest).Execute()
 	if err != nil {
-		if response.StatusCode == 429 {
+		if response != nil && response.StatusCode == 429 {
 			exceptionResponse, response, err = utils.RetryOn429(func() (*azionapi.WAFRuleResponse, *http.Response, error) {
 				return r.client.api.WAFsExceptionsAPI.UpdateWafException(ctx, exceptionID, plan.WafID.ValueInt64()).WAFRuleRequest(*wafRuleRequest).Execute()
 			}, 5)
@@ -385,14 +384,7 @@ func (r *wafRuleSetResource) Update(ctx context.Context, req resource.UpdateRequ
 				return
 			}
 		} else {
-			bodyBytes, errReadAll := io.ReadAll(response.Body)
-			if errReadAll != nil {
-				resp.Diagnostics.AddError(
-					errReadAll.Error(),
-					"err",
-				)
-			}
-			bodyString := string(bodyBytes)
+			bodyString := readAPIErrorBody(response)
 			resp.Diagnostics.AddError(
 				err.Error(),
 				bodyString,
@@ -452,14 +444,7 @@ func (r *wafRuleSetResource) Delete(ctx context.Context, req resource.DeleteRequ
 		if response != nil && response.StatusCode == http.StatusNotFound {
 			return
 		}
-		bodyBytes, errReadAll := io.ReadAll(response.Body)
-		if errReadAll != nil {
-			resp.Diagnostics.AddError(
-				errReadAll.Error(),
-				"err",
-			)
-		}
-		bodyString := string(bodyBytes)
+		bodyString := readAPIErrorBody(response)
 		resp.Diagnostics.AddError(
 			err.Error(),
 			bodyString,
@@ -469,7 +454,37 @@ func (r *wafRuleSetResource) Delete(ctx context.Context, req resource.DeleteRequ
 }
 
 func (r *wafRuleSetResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	parts := strings.Split(req.ID, "/")
+	if len(parts) != 2 {
+		resp.Diagnostics.AddError(
+			"Invalid import format",
+			"Expected format: wafID/exceptionID",
+		)
+		return
+	}
+
+	wafID, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid WAF ID format", err.Error())
+		return
+	}
+
+	exceptionID, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid WAF exception ID format", err.Error())
+		return
+	}
+
+	state := WafRuleSetResourceModel{
+		WafID: types.Int64Value(wafID),
+		ID:    types.StringValue(fmt.Sprintf("%d/%d", wafID, exceptionID)),
+		Result: &WafRuleSetResourceResults{
+			ID: types.Int64Value(exceptionID),
+		},
+	}
+
+	diags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
 }
 
 // transformWAFRuleToResourceModel transforms an SDK WAFRule to a Terraform resource model.

--- a/internal/resource_workload.go
+++ b/internal/resource_workload.go
@@ -2,14 +2,12 @@ package provider
 
 import (
 	"context"
-	"io"
 	"net/http"
 	"strconv"
 	"time"
 
 	azionapi "github.com/aziontech/azionapi-v4-go-sdk-dev/azion-api"
 	"github.com/aziontech/terraform-provider-azion/internal/utils"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -375,7 +373,7 @@ func (r *workloadResource) Create(ctx context.Context, req resource.CreateReques
 
 	createWorkload, response, err := r.client.api.WorkloadsAPI.CreateWorkload(ctx).WorkloadRequest(*workload).Execute()
 	if err != nil {
-		if response.StatusCode == 429 {
+		if response != nil && response.StatusCode == 429 {
 			createWorkload, response, err = utils.RetryOn429(func() (*azionapi.WorkloadResponse, *http.Response, error) {
 				return r.client.api.WorkloadsAPI.CreateWorkload(ctx).WorkloadRequest(*workload).Execute()
 			}, 5)
@@ -392,14 +390,7 @@ func (r *workloadResource) Create(ctx context.Context, req resource.CreateReques
 				return
 			}
 		} else {
-			bodyBytes, errReadAll := io.ReadAll(response.Body)
-			if errReadAll != nil {
-				resp.Diagnostics.AddError(
-					errReadAll.Error(),
-					"err",
-				)
-			}
-			bodyString := string(bodyBytes)
+			bodyString := readAPIErrorBody(response)
 			resp.Diagnostics.AddError(
 				err.Error(),
 				bodyString,
@@ -448,11 +439,11 @@ func (r *workloadResource) Read(ctx context.Context, req resource.ReadRequest, r
 
 	getWorkload, response, err := r.client.api.WorkloadsAPI.RetrieveWorkload(ctx, workloadId).Execute()
 	if err != nil {
-		if response.StatusCode == http.StatusNotFound {
+		if response != nil && response.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		if response.StatusCode == 429 {
+		if response != nil && response.StatusCode == 429 {
 			getWorkload, response, err = utils.RetryOn429(func() (*azionapi.WorkloadResponse, *http.Response, error) {
 				return r.client.api.WorkloadsAPI.RetrieveWorkload(ctx, workloadId).Execute()
 			}, 5)
@@ -469,14 +460,7 @@ func (r *workloadResource) Read(ctx context.Context, req resource.ReadRequest, r
 				return
 			}
 		} else {
-			bodyBytes, errReadAll := io.ReadAll(response.Body)
-			if errReadAll != nil {
-				resp.Diagnostics.AddError(
-					errReadAll.Error(),
-					"err",
-				)
-			}
-			bodyString := string(bodyBytes)
+			bodyString := readAPIErrorBody(response)
 			resp.Diagnostics.AddError(
 				err.Error(),
 				bodyString,
@@ -513,7 +497,20 @@ func (r *workloadResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	workloadId := state.Workload.ID.ValueInt64()
+	var workloadId int64
+	if state.Workload != nil && !state.Workload.ID.IsNull() {
+		workloadId = state.Workload.ID.ValueInt64()
+	} else {
+		parsedID, err := strconv.ParseInt(state.ID.ValueString(), 10, 64)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Value Conversion error ",
+				"Could not convert Workload ID",
+			)
+			return
+		}
+		workloadId = parsedID
+	}
 	updateWorkloadRequest := azionapi.NewPatchedWorkloadRequest()
 
 	// Set optional fields
@@ -639,7 +636,7 @@ func (r *workloadResource) Update(ctx context.Context, req resource.UpdateReques
 
 	updateWorkload, response, err := r.client.api.WorkloadsAPI.PartialUpdateWorkload(ctx, workloadId).PatchedWorkloadRequest(*updateWorkloadRequest).Execute()
 	if err != nil {
-		if response.StatusCode == 429 {
+		if response != nil && response.StatusCode == 429 {
 			updateWorkload, response, err = utils.RetryOn429(func() (*azionapi.WorkloadResponse, *http.Response, error) {
 				return r.client.api.WorkloadsAPI.PartialUpdateWorkload(ctx, workloadId).PatchedWorkloadRequest(*updateWorkloadRequest).Execute()
 			}, 5)
@@ -656,14 +653,7 @@ func (r *workloadResource) Update(ctx context.Context, req resource.UpdateReques
 				return
 			}
 		} else {
-			bodyBytes, errReadAll := io.ReadAll(response.Body)
-			if errReadAll != nil {
-				resp.Diagnostics.AddError(
-					errReadAll.Error(),
-					"err",
-				)
-			}
-			bodyString := string(bodyBytes)
+			bodyString := readAPIErrorBody(response)
 			resp.Diagnostics.AddError(
 				err.Error(),
 				bodyString,
@@ -694,7 +684,20 @@ func (r *workloadResource) Delete(ctx context.Context, req resource.DeleteReques
 		return
 	}
 
-	workloadId := state.Workload.ID.ValueInt64()
+	var workloadId int64
+	if state.Workload != nil && !state.Workload.ID.IsNull() {
+		workloadId = state.Workload.ID.ValueInt64()
+	} else {
+		parsedID, err := strconv.ParseInt(state.ID.ValueString(), 10, 64)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Value Conversion error ",
+				"Could not convert Workload ID",
+			)
+			return
+		}
+		workloadId = parsedID
+	}
 
 	_, response, err := utils.RetryOn429Delete(func() (*azionapi.DeleteResponse, *http.Response, error) {
 		return r.client.api.WorkloadsAPI.DeleteWorkload(ctx, workloadId).Execute()
@@ -706,14 +709,7 @@ func (r *workloadResource) Delete(ctx context.Context, req resource.DeleteReques
 		if response != nil && response.StatusCode == http.StatusNotFound {
 			return
 		}
-		bodyBytes, errReadAll := io.ReadAll(response.Body)
-		if errReadAll != nil {
-			resp.Diagnostics.AddError(
-				errReadAll.Error(),
-				"err",
-			)
-		}
-		bodyString := string(bodyBytes)
+		bodyString := readAPIErrorBody(response)
 		resp.Diagnostics.AddError(
 			err.Error(),
 			bodyString,
@@ -723,7 +719,22 @@ func (r *workloadResource) Delete(ctx context.Context, req resource.DeleteReques
 }
 
 func (r *workloadResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	workloadID, err := strconv.ParseInt(req.ID, 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid workload ID format", err.Error())
+		return
+	}
+
+	state := workloadResourceModel{
+		ID: types.StringValue(req.ID),
+		Workload: &workloadResourceResults{
+			ID:      types.Int64Value(workloadID),
+			Domains: types.SetNull(types.StringType),
+		},
+	}
+
+	diags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
 }
 
 // Helper function to populate workload results from API response.
@@ -744,8 +755,8 @@ func populateWorkloadResults(ctx context.Context, response *azionapi.WorkloadRes
 		ID:             types.Int64Value(response.Data.GetId()),
 		Name:           types.StringValue(response.Data.Name),
 		LastEditor:     types.StringValue(response.Data.GetLastEditor()),
-		LastModified:   types.StringValue(response.Data.LastModified.Format(time.RFC850)),
-		CreatedAt:      types.StringValue(response.Data.CreatedAt.Format(time.RFC3339)),
+		LastModified:   types.StringValue(response.Data.GetLastModified().Format(time.RFC850)),
+		CreatedAt:      types.StringValue(response.Data.GetCreatedAt().Format(time.RFC3339)),
 		ProductVersion: types.StringValue(response.Data.GetProductVersion()),
 		WorkloadDomain: types.StringValue(response.Data.GetWorkloadDomain()),
 	}
@@ -862,8 +873,11 @@ func populateWorkloadResults(ctx context.Context, response *azionapi.WorkloadRes
 
 	// Handle Domains.
 	if response.Data.Domains != nil {
-		domainsSet, _ := types.SetValueFrom(ctx, types.StringType, response.Data.Domains)
-		result.Domains = domainsSet
+		domains := make([]types.String, 0, len(response.Data.Domains))
+		for _, domain := range response.Data.Domains {
+			domains = append(domains, types.StringValue(domain))
+		}
+		result.Domains = utils.SliceStringTypeToSet(domains)
 	} else {
 		result.Domains = types.SetNull(types.StringType)
 	}

--- a/internal/resource_workload_deployment.go
+++ b/internal/resource_workload_deployment.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -201,7 +200,7 @@ func (r *workloadDeploymentResource) Create(ctx context.Context, req resource.Cr
 		CreateWorkloadDeployment(ctx, plan.WorkloadID.ValueInt64()).
 		WorkloadDeploymentRequest(*deploymentRequest).Execute()
 	if err != nil {
-		if response.StatusCode == 429 {
+		if response != nil && response.StatusCode == 429 {
 			createDeployment, response, err = utils.RetryOn429(func() (*azionapi.WorkloadDeploymentResponse, *http.Response, error) {
 				return r.client.api.WorkloadDeploymentsAPI.
 					CreateWorkloadDeployment(ctx, plan.WorkloadID.ValueInt64()).
@@ -216,14 +215,7 @@ func (r *workloadDeploymentResource) Create(ctx context.Context, req resource.Cr
 				return
 			}
 		} else {
-			bodyBytes, errReadAll := io.ReadAll(response.Body)
-			if errReadAll != nil {
-				resp.Diagnostics.AddError(
-					errReadAll.Error(),
-					"err",
-				)
-			}
-			bodyString := string(bodyBytes)
+			bodyString := readAPIErrorBody(response)
 			resp.Diagnostics.AddError(
 				err.Error(),
 				bodyString,
@@ -292,11 +284,11 @@ func (r *workloadDeploymentResource) Read(ctx context.Context, req resource.Read
 	deploymentResponse, response, err := r.client.api.WorkloadDeploymentsAPI.
 		RetrieveWorkloadDeployment(ctx, deploymentID, workloadID).Execute()
 	if err != nil {
-		if response.StatusCode == http.StatusNotFound {
+		if response != nil && response.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		if response.StatusCode == 429 {
+		if response != nil && response.StatusCode == 429 {
 			deploymentResponse, response, err = utils.RetryOn429(func() (*azionapi.WorkloadDeploymentResponse, *http.Response, error) {
 				return r.client.api.WorkloadDeploymentsAPI.
 					RetrieveWorkloadDeployment(ctx, deploymentID, workloadID).Execute()
@@ -310,14 +302,7 @@ func (r *workloadDeploymentResource) Read(ctx context.Context, req resource.Read
 				return
 			}
 		} else {
-			bodyBytes, errReadAll := io.ReadAll(response.Body)
-			if errReadAll != nil {
-				resp.Diagnostics.AddError(
-					errReadAll.Error(),
-					"err",
-				)
-			}
-			bodyString := string(bodyBytes)
+			bodyString := readAPIErrorBody(response)
 			resp.Diagnostics.AddError(
 				err.Error(),
 				bodyString,
@@ -409,7 +394,7 @@ func (r *workloadDeploymentResource) Update(ctx context.Context, req resource.Up
 		PartialUpdateWorkloadDeployment(ctx, deploymentID, plan.WorkloadID.ValueInt64()).
 		PatchedWorkloadDeploymentRequest(*patchedRequest).Execute()
 	if err != nil {
-		if response.StatusCode == 429 {
+		if response != nil && response.StatusCode == 429 {
 			updateResponse, response, err = utils.RetryOn429(func() (*azionapi.WorkloadDeploymentResponse, *http.Response, error) {
 				return r.client.api.WorkloadDeploymentsAPI.
 					PartialUpdateWorkloadDeployment(ctx, deploymentID, plan.WorkloadID.ValueInt64()).
@@ -424,14 +409,7 @@ func (r *workloadDeploymentResource) Update(ctx context.Context, req resource.Up
 				return
 			}
 		} else {
-			bodyBytes, errReadAll := io.ReadAll(response.Body)
-			if errReadAll != nil {
-				resp.Diagnostics.AddError(
-					errReadAll.Error(),
-					"err",
-				)
-			}
-			bodyString := string(bodyBytes)
+			bodyString := readAPIErrorBody(response)
 			resp.Diagnostics.AddError(
 				err.Error(),
 				bodyString,
@@ -490,14 +468,7 @@ func (r *workloadDeploymentResource) Delete(ctx context.Context, req resource.De
 			// Resource already deleted, consider this a success
 			return
 		}
-		bodyBytes, errReadAll := io.ReadAll(response.Body)
-		if errReadAll != nil {
-			resp.Diagnostics.AddError(
-				errReadAll.Error(),
-				"err",
-			)
-		}
-		bodyString := string(bodyBytes)
+		bodyString := readAPIErrorBody(response)
 		resp.Diagnostics.AddError(
 			err.Error(),
 			bodyString,
@@ -535,47 +506,12 @@ func (r *workloadDeploymentResource) ImportState(ctx context.Context, req resour
 		return
 	}
 
-	// Read the deployment to populate state
-	deploymentResponse, response, err := r.client.api.WorkloadDeploymentsAPI.
-		RetrieveWorkloadDeployment(ctx, deploymentID, workloadID).Execute()
-	if err != nil {
-		if response.StatusCode == 429 {
-			deploymentResponse, response, err = utils.RetryOn429(func() (*azionapi.WorkloadDeploymentResponse, *http.Response, error) {
-				return r.client.api.WorkloadDeploymentsAPI.
-					RetrieveWorkloadDeployment(ctx, deploymentID, workloadID).Execute()
-			}, 5)
-
-			if err != nil {
-				resp.Diagnostics.AddError(
-					err.Error(),
-					"API request failed after too many retries",
-				)
-				return
-			}
-		} else {
-			bodyBytes, errReadAll := io.ReadAll(response.Body)
-			if errReadAll != nil {
-				resp.Diagnostics.AddError(
-					errReadAll.Error(),
-					"err",
-				)
-			}
-			bodyString := string(bodyBytes)
-			resp.Diagnostics.AddError(
-				err.Error(),
-				bodyString,
-			)
-			return
-		}
-	}
-	if response != nil {
-		defer response.Body.Close()
-	}
-
 	state := WorkloadDeploymentResourceModel{
 		WorkloadID: types.Int64Value(workloadID),
-		ID:         types.StringValue(req.ID),
-		Deployment: populateDeploymentResults(deploymentResponse),
+		ID:         types.StringValue(fmt.Sprintf("%d/%d", workloadID, deploymentID)),
+		Deployment: &WorkloadDeploymentResourceResults{
+			ID: types.Int64Value(deploymentID),
+		},
 	}
 
 	diags := resp.State.Set(ctx, &state)

--- a/internal/resource_zones.go
+++ b/internal/resource_zones.go
@@ -3,14 +3,12 @@ package provider
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"strconv"
 	"time"
 
 	azionapi "github.com/aziontech/azionapi-v4-go-sdk-dev/azion-api"
 	"github.com/aziontech/terraform-provider-azion/internal/utils"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -125,7 +123,7 @@ func (r *zoneResource) Create(ctx context.Context, req resource.CreateRequest, r
 	zoneResponse, response, err := r.client.api.DNSZonesAPI.CreateDnsZone(ctx).
 		ZoneRequest(*zoneRequest).Execute()
 	if err != nil {
-		if response.StatusCode == 429 {
+		if response != nil && response.StatusCode == 429 {
 			zoneResponse, response, err = utils.RetryOn429(func() (*azionapi.ZoneResponse, *http.Response, error) {
 				return r.client.api.DNSZonesAPI.CreateDnsZone(ctx).
 					ZoneRequest(*zoneRequest).Execute()
@@ -143,14 +141,13 @@ func (r *zoneResource) Create(ctx context.Context, req resource.CreateRequest, r
 				return
 			}
 		} else {
-			bodyBytes, errReadAll := io.ReadAll(response.Body)
-			if errReadAll != nil {
-				resp.Diagnostics.AddError(errReadAll.Error(), "err")
-				return
+			bodyString := readAPIErrorBody(response)
+			if response == nil {
+				resp.Diagnostics.AddError(err.Error(), bodyString)
+			} else {
+				usrMsg, errMsg := errPrintZoneResource(response.StatusCode, err)
+				resp.Diagnostics.AddError(usrMsg, fmt.Sprintf("%s\nDetails: %s", errMsg, bodyString))
 			}
-			bodyString := string(bodyBytes)
-			usrMsg, errMsg := errPrintZoneResource(response.StatusCode, err)
-			resp.Diagnostics.AddError(usrMsg, fmt.Sprintf("%s\nDetails: %s", errMsg, bodyString))
 			return
 		}
 	}
@@ -215,11 +212,11 @@ func (r *zoneResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	zoneResponse, response, err := r.client.api.DNSZonesAPI.RetrieveDnsZone(ctx, zoneId).Execute()
 	if err != nil {
-		if response.StatusCode == http.StatusNotFound {
+		if response != nil && response.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		if response.StatusCode == 429 {
+		if response != nil && response.StatusCode == 429 {
 			zoneResponse, response, err = utils.RetryOn429(func() (*azionapi.ZoneResponse, *http.Response, error) {
 				return r.client.api.DNSZonesAPI.RetrieveDnsZone(ctx, zoneId).Execute()
 			}, 5)
@@ -236,8 +233,12 @@ func (r *zoneResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 				return
 			}
 		} else {
-			usrMsg, errMsg := errPrintZoneResource(response.StatusCode, err)
-			resp.Diagnostics.AddError(usrMsg, errMsg)
+			if response == nil {
+				resp.Diagnostics.AddError(err.Error(), "")
+			} else {
+				usrMsg, errMsg := errPrintZoneResource(response.StatusCode, err)
+				resp.Diagnostics.AddError(usrMsg, errMsg)
+			}
 			return
 		}
 	}
@@ -305,7 +306,7 @@ func (r *zoneResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	zoneResponse, response, err := r.client.api.DNSZonesAPI.UpdateDnsZone(ctx, zoneId).
 		UpdateZoneRequest(*updateRequest).Execute()
 	if err != nil {
-		if response.StatusCode == 429 {
+		if response != nil && response.StatusCode == 429 {
 			zoneResponse, response, err = utils.RetryOn429(func() (*azionapi.ZoneResponse, *http.Response, error) {
 				return r.client.api.DNSZonesAPI.UpdateDnsZone(ctx, zoneId).
 					UpdateZoneRequest(*updateRequest).Execute()
@@ -323,8 +324,12 @@ func (r *zoneResource) Update(ctx context.Context, req resource.UpdateRequest, r
 				return
 			}
 		} else {
-			usrMsg, errMsg := errPrintZoneResource(response.StatusCode, err)
-			resp.Diagnostics.AddError(usrMsg, errMsg)
+			if response == nil {
+				resp.Diagnostics.AddError(err.Error(), "")
+			} else {
+				usrMsg, errMsg := errPrintZoneResource(response.StatusCode, err)
+				resp.Diagnostics.AddError(usrMsg, errMsg)
+			}
 			return
 		}
 	}
@@ -396,14 +401,33 @@ func (r *zoneResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		if response != nil && response.StatusCode == http.StatusNotFound {
 			return
 		}
-		usrMsg, errMsg := errPrintZoneResource(response.StatusCode, err)
-		resp.Diagnostics.AddError(usrMsg, errMsg)
+		if response == nil {
+			resp.Diagnostics.AddError(err.Error(), "")
+		} else {
+			usrMsg, errMsg := errPrintZoneResource(response.StatusCode, err)
+			resp.Diagnostics.AddError(usrMsg, errMsg)
+		}
 		return
 	}
 }
 
 func (r *zoneResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	zoneID, err := strconv.ParseInt(req.ID, 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid zone ID format", err.Error())
+		return
+	}
+
+	state := zoneResourceModel{
+		ID: types.StringValue(req.ID),
+		Zone: &zoneModel{
+			ID:          types.Int64Value(zoneID),
+			Nameservers: types.ListNull(types.StringType),
+		},
+	}
+
+	diags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
 }
 
 func errPrintZoneResource(errCode int, err error) (string, string) {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -21,7 +21,7 @@ import (
 
 func SliceStringTypeToList(slice []types.String) types.List {
 	if len(slice) == 0 {
-		return types.ListValueMust(types.StringType, nil)
+		return types.ListNull(types.StringType)
 	}
 	strs := []attr.Value{}
 	for _, value := range slice {
@@ -54,7 +54,7 @@ func SliceStringTypeToSet(slice []types.String) types.Set {
 
 func SliceStringTypeToSetOrNull(slice []types.String) types.Set {
 	if len(slice) == 0 {
-		return types.SetValueMust(types.StringType, nil)
+		return types.SetNull(types.StringType)
 	}
 	strings := []attr.Value{}
 	for _, value := range slice {


### PR DESCRIPTION
Same pattern applied to the remaining resources: use the shared
readAPIErrorBody helper, guard response nil-checks so a nil response
doesn't panic, and simplify ImportState to seed minimal state from the
parsed ID(s) rather than making an extra API call before Terraform's
post-import Read.

Add nil guards for optional nested structs (WAF Result/EngineSettings,
NetworkList) that can now be absent right after import, and switch the
WAF rule set and DNS record/zone resources to a composite
"parent/child" import ID format for consistency with the other child
resources.